### PR TITLE
feat: Implement GitHub API PR list fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -434,6 +435,18 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -448,7 +461,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1571,7 +1587,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crossterm = "0.29.0"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,5 +1,9 @@
 #[allow(dead_code)]
+pub mod pull_request;
+#[allow(dead_code)]
 pub mod types;
 
+#[allow(unused_imports)]
+pub use pull_request::PrInfo;
 #[allow(unused_imports)]
 pub use types::PullRequest;

--- a/src/github/pull_request.rs
+++ b/src/github/pull_request.rs
@@ -1,0 +1,203 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// Information about a GitHub pull request.
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub state: String,
+    pub head_branch: String,
+    pub updated_at: String,
+    pub additions: u64,
+    pub deletions: u64,
+    pub changed_files: u64,
+}
+
+/// Raw GitHub API response for a pull request.
+#[derive(Debug, Deserialize)]
+struct GhPullRequest {
+    number: u64,
+    title: String,
+    state: String,
+    user: GhUser,
+    head: GhHead,
+    updated_at: String,
+    #[serde(default)]
+    additions: u64,
+    #[serde(default)]
+    deletions: u64,
+    #[serde(default)]
+    changed_files: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhHead {
+    #[serde(rename = "ref")]
+    ref_name: String,
+}
+
+impl From<GhPullRequest> for PrInfo {
+    fn from(pr: GhPullRequest) -> Self {
+        Self {
+            number: pr.number,
+            title: pr.title,
+            author: pr.user.login,
+            state: pr.state,
+            head_branch: pr.head.ref_name,
+            updated_at: pr.updated_at,
+            additions: pr.additions,
+            deletions: pr.deletions,
+            changed_files: pr.changed_files,
+        }
+    }
+}
+
+/// Fetch open pull requests from a GitHub repository.
+///
+/// Calls `GET /repos/{owner}/{repo}/pulls` with the given token for authentication.
+/// The token should be a GitHub personal access token or similar.
+pub fn list_pull_requests(owner: &str, repo: &str, token: &str) -> Result<Vec<PrInfo>> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/pulls?state=open&per_page=100");
+
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("User-Agent", "reown")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .with_context(|| format!("Failed to fetch PRs from {owner}/{repo}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        anyhow::bail!("GitHub API returned {status}: {body}");
+    }
+
+    let prs: Vec<GhPullRequest> = response
+        .json()
+        .context("Failed to parse GitHub PR response")?;
+
+    Ok(prs.into_iter().map(PrInfo::from).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that a valid GitHub API JSON response deserializes correctly into PrInfo.
+    #[test]
+    fn test_parse_pr_response() {
+        let json = r#"[
+            {
+                "number": 42,
+                "title": "Add feature X",
+                "state": "open",
+                "user": { "login": "alice" },
+                "head": { "ref": "feature-x" },
+                "updated_at": "2025-01-15T10:30:00Z",
+                "additions": 100,
+                "deletions": 20,
+                "changed_files": 5
+            },
+            {
+                "number": 43,
+                "title": "Fix bug Y",
+                "state": "open",
+                "user": { "login": "bob" },
+                "head": { "ref": "fix-bug-y" },
+                "updated_at": "2025-01-16T08:00:00Z",
+                "additions": 10,
+                "deletions": 3,
+                "changed_files": 2
+            }
+        ]"#;
+
+        let gh_prs: Vec<GhPullRequest> = serde_json::from_str(json).unwrap();
+        let prs: Vec<PrInfo> = gh_prs.into_iter().map(PrInfo::from).collect();
+
+        assert_eq!(prs.len(), 2);
+
+        assert_eq!(prs[0].number, 42);
+        assert_eq!(prs[0].title, "Add feature X");
+        assert_eq!(prs[0].author, "alice");
+        assert_eq!(prs[0].state, "open");
+        assert_eq!(prs[0].head_branch, "feature-x");
+        assert_eq!(prs[0].updated_at, "2025-01-15T10:30:00Z");
+        assert_eq!(prs[0].additions, 100);
+        assert_eq!(prs[0].deletions, 20);
+        assert_eq!(prs[0].changed_files, 5);
+
+        assert_eq!(prs[1].number, 43);
+        assert_eq!(prs[1].title, "Fix bug Y");
+        assert_eq!(prs[1].author, "bob");
+        assert_eq!(prs[1].state, "open");
+        assert_eq!(prs[1].head_branch, "fix-bug-y");
+    }
+
+    /// Test that missing optional numeric fields default to 0.
+    #[test]
+    fn test_parse_pr_missing_stats() {
+        let json = r#"[
+            {
+                "number": 1,
+                "title": "Minimal PR",
+                "state": "open",
+                "user": { "login": "dev" },
+                "head": { "ref": "main" },
+                "updated_at": "2025-02-01T00:00:00Z"
+            }
+        ]"#;
+
+        let gh_prs: Vec<GhPullRequest> = serde_json::from_str(json).unwrap();
+        let prs: Vec<PrInfo> = gh_prs.into_iter().map(PrInfo::from).collect();
+
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 1);
+        assert_eq!(prs[0].additions, 0);
+        assert_eq!(prs[0].deletions, 0);
+        assert_eq!(prs[0].changed_files, 0);
+    }
+
+    /// Test parsing an empty response.
+    #[test]
+    fn test_parse_empty_pr_list() {
+        let json = "[]";
+        let gh_prs: Vec<GhPullRequest> = serde_json::from_str(json).unwrap();
+        let prs: Vec<PrInfo> = gh_prs.into_iter().map(PrInfo::from).collect();
+        assert!(prs.is_empty());
+    }
+
+    /// Test that a closed PR state is preserved correctly.
+    #[test]
+    fn test_parse_closed_pr() {
+        let json = r#"[
+            {
+                "number": 99,
+                "title": "Old PR",
+                "state": "closed",
+                "user": { "login": "charlie" },
+                "head": { "ref": "old-branch" },
+                "updated_at": "2024-12-01T12:00:00Z",
+                "additions": 50,
+                "deletions": 50,
+                "changed_files": 10
+            }
+        ]"#;
+
+        let gh_prs: Vec<GhPullRequest> = serde_json::from_str(json).unwrap();
+        let prs: Vec<PrInfo> = gh_prs.into_iter().map(PrInfo::from).collect();
+
+        assert_eq!(prs[0].state, "closed");
+        assert_eq!(prs[0].author, "charlie");
+        assert_eq!(prs[0].head_branch, "old-branch");
+    }
+}


### PR DESCRIPTION
## Summary

Implements task **phase2-002**: Implement GitHub API PR list fetching

In src/github/pull_request.rs, implement list_pull_requests(owner, repo, token) -> Result<Vec<PrInfo>> using reqwest to call GET /repos/{owner}/{repo}/pulls. PrInfo struct: number, title, author, state, head_branch, updated_at, additions, deletions, changed_files. Include unit tests with mock responses.

---
Generated by agent/loop.sh