### PR TITLE
feat: Add PR list view to TUI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::git::{
     diff::{self, FileDiff},
     worktree::{self, WorktreeInfo},
 };
+use crate::github::PrInfo;
 use anyhow::Result;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,6 +11,7 @@ pub enum View {
     Worktrees,
     Branches,
     Diff,
+    PullRequests,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +43,9 @@ pub struct App {
     pub diff_file_sel: usize,
     pub diff_scroll: u16,
 
+    // Pull Requests tab
+    pub pull_requests: Vec<PrInfo>,
+    pub pr_sel: usize,
 }
 
 impl App {
@@ -90,6 +95,8 @@ impl App {
             file_diffs,
             diff_file_sel: 0,
             diff_scroll: 0,
+            pull_requests: Vec::new(),
+            pr_sel: 0,
         })
     }
 
@@ -150,6 +157,13 @@ impl App {
         } else if self.diff_file_sel >= d_len {
             self.diff_file_sel = d_len - 1;
         }
+
+        let pr_len = self.pull_requests.len();
+        if pr_len == 0 {
+            self.pr_sel = 0;
+        } else if self.pr_sel >= pr_len {
+            self.pr_sel = pr_len - 1;
+        }
     }
 
     // ── Navigation ────────────────────────────────────────────────────────
@@ -173,6 +187,11 @@ impl App {
                     self.diff_scroll = 0;
                 }
             }
+            View::PullRequests => {
+                if !self.pull_requests.is_empty() {
+                    self.pr_sel = (self.pr_sel + 1).min(self.pull_requests.len() - 1);
+                }
+            }
         }
     }
 
@@ -187,6 +206,9 @@ impl App {
             View::Diff => {
                 self.diff_file_sel = self.diff_file_sel.saturating_sub(1);
                 self.diff_scroll = 0;
+            }
+            View::PullRequests => {
+                self.pr_sel = self.pr_sel.saturating_sub(1);
             }
         }
     }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -3,7 +3,6 @@ pub mod pull_request;
 #[allow(dead_code)]
 pub mod types;
 
-#[allow(unused_imports)]
 pub use pull_request::PrInfo;
 #[allow(unused_imports)]
 pub use types::PullRequest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,13 +103,15 @@ fn run_app(
                         app.view = match app.view {
                             View::Worktrees => View::Branches,
                             View::Branches => View::Diff,
-                            View::Diff => View::Worktrees,
+                            View::Diff => View::PullRequests,
+                            View::PullRequests => View::Worktrees,
                         };
                     }
                     // View shortcuts
                     KeyCode::Char('w') => app.view = View::Worktrees,
                     KeyCode::Char('b') => app.view = View::Branches,
                     KeyCode::Char('d') => app.view = View::Diff,
+                    KeyCode::Char('p') => app.view = View::PullRequests,
                     // Navigation
                     KeyCode::Down | KeyCode::Char('j') => {
                         if app.view == View::Diff {
@@ -154,7 +156,7 @@ fn run_app(
                                     .into(),
                             );
                         }
-                        View::Diff => {}
+                        View::Diff | View::PullRequests => {}
                     },
                     KeyCode::Enter => {
                         if app.view == View::Branches {
@@ -206,6 +208,8 @@ fn draw(frame: &mut ratatui::Frame, app: &App) {
         Span::styled(" [b] Branches ", tab_style(View::Branches)),
         Span::raw(" "),
         Span::styled(" [d] Diff ", tab_style(View::Diff)),
+        Span::raw(" "),
+        Span::styled(" [p] PRs ", tab_style(View::PullRequests)),
         Span::raw("  ─  Tab:next  q:quit  r:refresh"),
     ]);
     frame.render_widget(
@@ -240,6 +244,15 @@ fn draw(frame: &mut ratatui::Frame, app: &App) {
                 &app.file_diffs,
                 app.diff_file_sel,
                 app.diff_scroll,
+                true,
+            );
+        }
+        View::PullRequests => {
+            ui::pull_request::render_pull_requests(
+                frame,
+                outer[1],
+                &app.pull_requests,
+                app.pr_sel,
                 true,
             );
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
-pub mod diff;
-pub mod worktree;
 pub mod branch;
+pub mod diff;
+pub mod pull_request;
+pub mod worktree;

--- a/src/ui/pull_request.rs
+++ b/src/ui/pull_request.rs
@@ -1,0 +1,180 @@
+use crate::github::PrInfo;
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState},
+    Frame,
+};
+
+/// Render the pull requests panel into `area`.
+pub fn render_pull_requests(
+    frame: &mut Frame,
+    area: Rect,
+    pull_requests: &[PrInfo],
+    selected: usize,
+    focused: bool,
+) {
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+
+    let items: Vec<ListItem> = pull_requests
+        .iter()
+        .map(|pr| {
+            let state_style = match pr.state.as_str() {
+                "open" => Style::default().fg(Color::Green),
+                "closed" => Style::default().fg(Color::Red),
+                _ => Style::default().fg(Color::Yellow),
+            };
+            let number = format!("#{:<5}", pr.number);
+            let title = if pr.title.len() > 50 {
+                format!("{}…", &pr.title[..49])
+            } else {
+                format!("{:<50}", pr.title)
+            };
+            let author = format!("  @{}", pr.author);
+            let line = Line::from(vec![
+                Span::styled(number, Style::default().fg(Color::Cyan)),
+                Span::styled(
+                    format!(" {} ", pr.state.to_uppercase()),
+                    state_style,
+                ),
+                Span::styled(title, Style::default().fg(Color::White)),
+                Span::styled(author, Style::default().fg(Color::DarkGray)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(" Pull Requests [p] ")
+                .borders(Borders::ALL)
+                .border_style(border_style),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn sample_prs() -> Vec<PrInfo> {
+        vec![
+            PrInfo {
+                number: 42,
+                title: "Add feature X".to_string(),
+                author: "alice".to_string(),
+                state: "open".to_string(),
+                head_branch: "feature-x".to_string(),
+                updated_at: "2025-01-15T10:30:00Z".to_string(),
+                additions: 100,
+                deletions: 20,
+                changed_files: 5,
+            },
+            PrInfo {
+                number: 43,
+                title: "Fix bug Y".to_string(),
+                author: "bob".to_string(),
+                state: "closed".to_string(),
+                head_branch: "fix-bug-y".to_string(),
+                updated_at: "2025-01-16T08:00:00Z".to_string(),
+                additions: 10,
+                deletions: 3,
+                changed_files: 2,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_render_pull_requests_no_panic() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let prs = sample_prs();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_pull_requests(frame, area, &prs, 0, true);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_empty_pull_requests_no_panic() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_pull_requests(frame, area, &[], 0, false);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_pull_requests_contains_pr_number() {
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let prs = sample_prs();
+
+        let result = terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_pull_requests(frame, area, &prs, 0, true);
+            })
+            .unwrap();
+
+        let buffer = result.buffer;
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().chars().next().unwrap_or(' '))
+            .collect();
+
+        assert!(content.contains("#42"));
+        assert!(content.contains("#43"));
+        assert!(content.contains("alice"));
+        assert!(content.contains("bob"));
+    }
+
+    #[test]
+    fn test_render_long_title_truncated() {
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let prs = vec![PrInfo {
+            number: 1,
+            title: "A very long title that exceeds fifty characters and should be truncated with an ellipsis".to_string(),
+            author: "dev".to_string(),
+            state: "open".to_string(),
+            head_branch: "long-branch".to_string(),
+            updated_at: "2025-01-01T00:00:00Z".to_string(),
+            additions: 0,
+            deletions: 0,
+            changed_files: 0,
+        }];
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_pull_requests(frame, area, &prs, 0, true);
+            })
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Implements task **phase2-003**: Add PR list view to TUI

Add View::PullRequests variant. Create src/ui/pull_request.rs with render_pull_requests() following the same pattern as render_branches(). Add 'p' hotkey to switch to PR view. Show PR number, title, author, status. This is the single surface for reviewing agent PRs, Devin/Copilot PRs, and colleague PRs.

---
Generated by agent/loop.sh