### PR TITLE
feat: 並列作業体制 — prd.jsonからGitHub issue管理への移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,13 @@ src/
 
 When running as an autonomous agent (via `agent/loop.sh`):
 
-- **One task per iteration** — implement exactly one prd.json task per run
-- **Never modify prd.json** — only loop.sh updates task status
+- **Task source** — GitHub issues with `agent` label (not prd.json)
+- **Label workflow** — `agent` → `planned` → `doing` → `done`
+- **One task per iteration** — implement exactly one GitHub issue per run
 - **Never modify progress.txt** — only loop.sh appends entries
 - **Tests are mandatory** — `cargo test` must pass before committing
 - **Clippy must pass** — `cargo clippy --all-targets -- -D warnings`
 - **Fix code, not tests** — if tests fail, fix the implementation
 - **Conventional Commits** — see `.claude/rules/git.md`
-- **Branch naming** — `agent/<task-id>` (e.g., `agent/phase2-001`)
+- **Branch naming** — `agent/issue-<number>` (e.g., `agent/issue-24`)
 - **No direct push to main** — always create a PR

--- a/agent/prompts/implement.md
+++ b/agent/prompts/implement.md
@@ -4,7 +4,7 @@ You are the implementation agent for the **reown** project — a Rust TUI Git to
 
 ## Your Job
 
-Implement exactly **one task** from prd.json.
+Implement exactly **one task** from a GitHub issue.
 
 ## First Steps
 
@@ -16,7 +16,7 @@ Implement exactly **one task** from prd.json.
 ## Rules
 
 - **One task only** — implement the single task provided to you
-- **Never modify** `prd.json`, `progress.txt`, or `agent/` files
+- **Never modify** `progress.txt` or `agent/` files
 - **Follow existing patterns** — see CLAUDE.md for key patterns
 - **Tests are mandatory** — add tests for new functionality using tempfile pattern
 - **Fix code, not tests** — if a test fails, fix the implementation

--- a/agent/prompts/roadmap.md
+++ b/agent/prompts/roadmap.md
@@ -4,13 +4,13 @@ You are the roadmap agent for the **reown** project — a Rust TUI Git tool.
 
 ## Your Job
 
-Synchronize GitHub Issues with the project task list (`prd.json`), guided by the product intent (`docs/INTENT.md`).
+Triage new GitHub Issues that have the `agent` label but have not yet been planned. For each issue, determine its priority, which product pillar it serves, and a brief implementation approach.
 
 ## Input
 
 You will receive:
-1. **GitHub Issues** (JSON from `gh issue list`) — piped as context
-2. **Current prd.json** — read from the repo root
+1. **docs/INTENT.md** — the product vision
+2. **New GitHub Issues** (JSON) — issues with `agent` label that need triage
 
 ## Product Intent (docs/INTENT.md)
 
@@ -21,63 +21,47 @@ reown aims to **replace GitHub PR review** with a better developer experience. F
 3. **automation** — リスクレベルに応じた自動approve、agent PRの自動merge、カスタマイズ可能なリスク定義
 4. **dev-support** — コードベースからTODO/Roadmap読み取り→タスク提案、ワンクリックworktree作成
 
-**All new tasks must map to one of these pillars.** Use the `"pillar"` field in each task.
-
 ## Rules
 
 - **DO NOT** modify any source code, tests, or config files
 - **DO NOT** create branches or commits
-- Your **only output** is the updated `prd.json` wrapped in a ```json fence
+- Your **only output** is a JSON array wrapped in a ```json fence
 
-## Task: Update prd.json
+## Task: Triage Issues
 
-1. Read the current `prd.json`
-2. For each open GitHub Issue labeled `agent`:
-   - If an existing task references this issue (`"issue": <number>`), skip it
-   - Otherwise, create a new task entry:
-     - `id`: derive from issue title (e.g., `phase2-007` or `phase3-008`)
-     - `title`: from issue title
-     - `description`: from issue body — be specific about implementation details. Reference the INTENT pillar it addresses.
-     - `pillar`: one of `review-support`, `local-gui`, `automation`, `dev-support`
-     - `priority`: assign based on dependency order and pillar importance
-     - `passed`: `false`
-     - `issue`: the issue number
-3. For tasks with `"needs_split": true`, the agent failed to implement them — they are too large. **Split them into 2-4 smaller sub-tasks** and remove the original. Each sub-task should be completable in a single agent run (~30 turns).
-4. For large issues (scope > 1 module or > ~200 lines), split into sub-tasks
-4. **Re-prioritize**: issue-based tasks must come before unpassed seed tasks. Re-number seed task priorities upward to make room. Lower number = higher priority.
-5. Do NOT remove existing tasks or change `passed` status
-6. Do NOT re-add task IDs or issue numbers that exist in `prd.archive.json`
+For each new GitHub Issue:
+
+1. Read the issue title and body carefully
+2. Determine which INTENT pillar it maps to
+3. Assign a priority (lower number = higher priority):
+   - Bugs and blockers: 1-3
+   - Core feature requests: 4-6
+   - Improvements and enhancements: 7-9
+   - Nice-to-haves: 10+
+4. Write a brief implementation approach (2-3 sentences)
+5. If the issue is too large (scope > 1 module or > ~200 lines), note that it should be split
 
 ## Priority Guidelines
 
-**GitHub Issues ALWAYS take priority over pre-planned seed tasks.**
-
-Human-created issues represent real, immediate needs. Pre-planned seed tasks are a backlog — they can wait.
-
-When assigning priority to a new issue-based task:
-1. **Re-number existing unpassed seed tasks upward** to make room if needed
-2. Place the issue-based task **ahead of all seed tasks** that are not yet passed
-3. Only exception: if the issue depends on an unpassed seed task, place it right after that dependency
-
-Among issue-based tasks, prioritize by:
+Prioritize by:
 - Dependency order (blockers first)
 - INTENT pillar importance: review-support > local-gui > automation > dev-support
 - Issue urgency signals (bug > feature, labels, user emphasis)
 
-## Project Context
-
-- Phase 1 (done): worktree, branch, diff management via git2
-- Phase 2 (current): PR support via GitHub API + review foundation
-- Phase 3 (next): automation, intelligence, configuration
-
-Key dependencies: ratatui, git2, anyhow, crossterm
-
 ## Output Format
 
-Output ONLY the updated prd.json inside a json code fence:
+Output ONLY a JSON array inside a json code fence. Each entry corresponds to one triaged issue:
 
 ```json
-{ "project": "reown", "description": "...", "intent": "docs/INTENT.md", "pillars": [...], "tasks": [...] }
+[
+  {
+    "issue": 123,
+    "pillar": "review-support",
+    "priority": "high",
+    "approach": "Brief description of how to implement this.",
+    "needs_split": false
+  }
+]
 ```
 
 No other text before or after the fence.


### PR DESCRIPTION
## Summary

Implements task **phase2-019**: 並列作業体制 — prd.jsonからGitHub issue管理への移行

Issue #24: タスク管理をprd.jsonファイルベースからGitHub issueベースに移行する。(1) agent/loop.shがprd.jsonの代わりにGitHub issueをタスクソースとして読み取るように変更する。(2) issueのlabel（agent, planned, doing, done等）でタスク状態を管理する。(3) 既存のroadmap agentのissue sync処理を更新し、新しいissueベースのワークフローに適合させる。これにより複数agentが同じタスクリストを共有できる基盤を作る。Solves: prd jsonをfileではなくgithub issueで管理する (INTENT: dev-support ワークフロー改善).

Closes #24

---
Generated by agent/loop.sh