### PR TITLE
feat: ドキュメント・テンプレートの日本語化

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,4 +1,4 @@
-# Git Commit Rules
+# Git Commit Rules / Gitコミットルール
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 
@@ -6,19 +6,20 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 <prefix>: <summary>
 ```
 
-## Prefixes
+## Prefixes / プレフィックス
 
-- `feat` — new feature
-- `fix` — bug fix
-- `refactor` — code restructuring (no behavior change)
-- `docs` — documentation only
-- `test` — adding or updating tests
-- `chore` — build, config, dependencies, CI
-- `perf` — performance improvement
-- `style` — formatting, linting (no logic change)
+- `feat` — 新機能
+- `fix` — バグ修正
+- `refactor` — コードの再構成（動作変更なし）
+- `docs` — ドキュメントのみ
+- `test` — テストの追加・更新
+- `chore` — ビルド、設定、依存関係、CI
+- `perf` — パフォーマンス改善
+- `style` — フォーマット、lint（ロジック変更なし）
 
-## Rules
+## Rules / ルール
 
-- Summary is lowercase, imperative mood, no period
-- Keep the first line under 72 characters
-- Add body for non-trivial changes (separated by blank line)
+- サマリーは小文字、命令形、ピリオドなし
+- 1行目は72文字以内に収める
+- 重要な変更には本文を追加する（空行で区切る）
+- サマリーは英語で記述し、本文は日本語で記述してもよい

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,94 +1,94 @@
-name: Bug Report
-description: Report a bug to help improve reown
+name: バグ報告
+description: reownの改善のためにバグを報告する
 labels: ["bug", "agent"]
 body:
   - type: input
     id: title_summary
     attributes:
-      label: Summary
-      description: A short, descriptive summary of the bug (e.g. "Diff view crashes on binary files")
-      placeholder: "<component>: <what goes wrong>"
+      label: 概要
+      description: バグの短い説明（例：「Diffビューがバイナリファイルでクラッシュする」）
+      placeholder: "<コンポーネント>: <何が問題か>"
     validations:
       required: true
 
   - type: textarea
     id: goal
     attributes:
-      label: Goal
-      description: What is the expected correct behavior?
+      label: ゴール
+      description: 期待される正しい動作は何ですか？
       placeholder: |
-        Describe what should happen when the bug is fixed.
-        Example: "The diff view should skip binary files and show a placeholder instead of crashing."
+        バグが修正された後にどうなるべきかを記述してください。
+        例：「Diffビューはバイナリファイルをスキップし、クラッシュではなくプレースホルダーを表示するべき。」
     validations:
       required: true
 
   - type: textarea
     id: context
     attributes:
-      label: Context
-      description: Provide context to reproduce the bug and understand where it occurs.
+      label: 背景
+      description: バグの再現手順と発生箇所のコンテキストを提供してください。
       value: |
-        **Steps to reproduce:**
+        **再現手順：**
         1.
         2.
         3.
 
-        **Actual behavior:**
+        **実際の動作：**
 
 
-        **Environment:**
+        **環境：**
         - OS:
-        - reown version:
-        - Rust version:
+        - reown バージョン:
+        - Rust バージョン:
     validations:
       required: true
 
   - type: textarea
     id: acceptance_criteria
     attributes:
-      label: Acceptance Criteria
-      description: Define the conditions that must be met for this bug to be considered fixed.
+      label: 受け入れ基準
+      description: このバグが修正されたと見なすための条件を定義してください。
       placeholder: |
-        - [ ] <specific condition that must be true>
-        - [ ] No regression in existing tests
-        - [ ] cargo test passes
+        - [ ] <満たすべき具体的な条件>
+        - [ ] 既存テストのリグレッションがない
+        - [ ] cargo test が通る
     validations:
       required: true
 
   - type: dropdown
     id: component
     attributes:
-      label: Component
-      description: Which part of reown is affected?
+      label: コンポーネント
+      description: reownのどの部分が影響を受けていますか？
       options:
-        - Diff viewer
-        - Branch management
-        - Worktree management
-        - PR list / GitHub integration
-        - UI / rendering
-        - CLI / startup
-        - Other
+        - Diffビューア
+        - ブランチ管理
+        - ワークツリー管理
+        - PRリスト / GitHub連携
+        - UI / レンダリング
+        - CLI / 起動
+        - その他
     validations:
       required: true
 
   - type: dropdown
     id: severity
     attributes:
-      label: Severity
-      description: How severe is this bug?
+      label: 重要度
+      description: このバグの深刻度はどのくらいですか？
       options:
-        - crash — app panics or exits unexpectedly
-        - major — feature is broken or unusable
-        - minor — feature works but has issues
-        - cosmetic — visual or formatting issue
+        - crash — アプリがパニックまたは予期せず終了する
+        - major — 機能が壊れているか使用不能
+        - minor — 機能は動くが問題がある
+        - cosmetic — 表示やフォーマットの問題
     validations:
       required: true
 
   - type: textarea
     id: additional
     attributes:
-      label: Additional Information
-      description: Any additional context, logs, screenshots, or references.
-      placeholder: Paste error logs, stack traces, or screenshots here.
+      label: 補足情報
+      description: 追加のコンテキスト、ログ、スクリーンショット、参考資料等。
+      placeholder: エラーログ、スタックトレース、スクリーンショットをここに貼り付けてください。
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,80 +1,80 @@
-name: Feature Request
-description: Propose a new feature or enhancement for reown
+name: 機能リクエスト
+description: reownの新機能や改善を提案する
 labels: ["enhancement", "agent"]
 body:
   - type: input
     id: title_summary
     attributes:
-      label: Summary
-      description: A short, descriptive summary of the feature (e.g. "Add keyboard shortcut to approve PR")
-      placeholder: "<action verb> <what> in <where>"
+      label: 概要
+      description: 機能の短い説明（例：「PRを承認するキーボードショートカットを追加」）
+      placeholder: "<動詞> <対象> を <場所> に"
     validations:
       required: true
 
   - type: textarea
     id: goal
     attributes:
-      label: Goal
-      description: What should this feature achieve? Describe the desired outcome.
+      label: ゴール
+      description: この機能で何を達成したいですか？期待する結果を記述してください。
       placeholder: |
-        Describe what the user should be able to do after this feature is implemented.
-        Example: "Users should be able to approve a PR directly from the PR detail view by pressing 'a'."
+        この機能が実装された後、ユーザーが何をできるようになるかを記述してください。
+        例：「PR詳細ビューで 'a' キーを押してPRを直接承認できるようにする。」
     validations:
       required: true
 
   - type: textarea
     id: context
     attributes:
-      label: Context
-      description: Why is this feature needed? What problem does it solve?
+      label: 背景
+      description: なぜこの機能が必要ですか？どんな問題を解決しますか？
       placeholder: |
-        Describe the current pain point or limitation.
-        Example: "Currently users must switch to the browser to approve PRs, breaking the local-first workflow."
+        現在のペインや制限を記述してください。
+        例：「現在、PRを承認するにはブラウザに切り替える必要があり、ローカルファーストのワークフローが中断される。」
     validations:
       required: true
 
   - type: textarea
     id: acceptance_criteria
     attributes:
-      label: Acceptance Criteria
-      description: Define the conditions that must be met for this feature to be considered complete.
+      label: 受け入れ基準
+      description: この機能が完了したと見なすための条件を定義してください。
       placeholder: |
-        - [ ] <specific condition that must be true>
-        - [ ] Unit tests cover the new functionality
-        - [ ] cargo test and cargo clippy pass
+        - [ ] <満たすべき具体的な条件>
+        - [ ] 新機能のユニットテストがある
+        - [ ] cargo test と cargo clippy が通る
     validations:
       required: true
 
   - type: dropdown
     id: pillar
     attributes:
-      label: Pillar
-      description: Which product pillar does this feature serve? (See docs/INTENT.md)
+      label: ピラー
+      description: この機能はどのプロダクトピラーに該当しますか？（docs/INTENT.md参照）
       options:
-        - review-support — impact analysis, risk assessment, review patterns
-        - local-gui — unified local interface for all PR reviews
-        - automation — auto-approve, auto-merge based on risk
-        - dev-support — task suggestions, worktree creation
+        - review-support — 影響範囲分析、リスク評価、レビューパターン
+        - local-gui — すべてのPRレビューのための統合ローカルインターフェース
+        - automation — リスクに基づく自動承認・自動マージ
+        - dev-support — タスク提案、ワークツリー作成
     validations:
       required: true
 
   - type: dropdown
     id: scope
     attributes:
-      label: Estimated Scope
-      description: How large is this feature?
+      label: 推定スコープ
+      description: この機能の規模はどのくらいですか？
       options:
-        - small — single file change, isolated logic
-        - medium — multiple files, one module
-        - large — cross-module, architectural change
+        - small — 単一ファイルの変更、独立したロジック
+        - medium — 複数ファイル、1モジュール
+        - large — モジュール横断、アーキテクチャ変更
     validations:
       required: true
 
   - type: textarea
     id: additional
     attributes:
-      label: Additional Information
-      description: Any additional context, mockups, references, or related issues.
-      placeholder: Links to related issues, mockups, or design docs.
+      label: 補足情報
+      description: 追加のコンテキスト、モックアップ、参考資料、関連Issue等。
+      placeholder: 関連Issue、モックアップ、設計ドキュメントへのリンク。
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/general_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/general_feedback.yml
@@ -1,58 +1,58 @@
-name: General Feedback
-description: Share feedback, ideas, or requests that don't fit bug reports or feature requests
+name: 一般フィードバック
+description: バグ報告や機能リクエストに当てはまらないフィードバック、アイデア、要望を共有する
 labels: ["feedback"]
 body:
   - type: input
     id: title_summary
     attributes:
-      label: Summary
-      description: A short summary of your feedback or request
-      placeholder: "e.g. Improve worktree creation workflow"
+      label: 概要
+      description: フィードバックや要望の短い要約
+      placeholder: "例：ワークツリー作成ワークフローの改善"
     validations:
       required: true
 
   - type: dropdown
     id: priority
     attributes:
-      label: Priority
-      description: How important is this to you?
+      label: 優先度
+      description: あなたにとってどのくらい重要ですか？
       options:
-        - high — blocking or significantly impacting my workflow
-        - medium — would noticeably improve my experience
-        - low — nice to have, no urgency
+        - high — ワークフローをブロックまたは大きく影響している
+        - medium — 体験を顕著に改善する
+        - low — あると嬉しいが、緊急性はない
     validations:
       required: true
 
   - type: dropdown
     id: category
     attributes:
-      label: Category
-      description: What area does this feedback relate to?
+      label: カテゴリ
+      description: このフィードバックはどの領域に関するものですか？
       options:
-        - product — features, UX, behavior
-        - dev-environment — build, tooling, local setup
-        - workflow — CI/CD, automation, agent loop
-        - documentation — README, docs, comments
-        - other
+        - product — 機能、UX、動作
+        - dev-environment — ビルド、ツール、ローカルセットアップ
+        - workflow — CI/CD、自動化、エージェントループ
+        - documentation — README、ドキュメント、コメント
+        - other — その他
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: Describe your feedback, idea, or request in detail. Free-form — any format is welcome.
+      label: 詳細
+      description: フィードバック、アイデア、要望を詳しく記述してください。自由形式で構いません。
       placeholder: |
-        What's on your mind? Describe the problem, suggestion, or idea.
-        Feel free to include examples, screenshots, or references.
+        何を考えていますか？問題、提案、アイデアを記述してください。
+        例、スクリーンショット、参考資料を含めても構いません。
     validations:
       required: true
 
   - type: textarea
     id: additional
     attributes:
-      label: Additional Context
-      description: Any extra context, links, or references.
-      placeholder: Related issues, links, screenshots, etc.
+      label: 補足情報
+      description: 追加のコンテキスト、リンク、参考資料。
+      placeholder: 関連Issue、リンク、スクリーンショット等。
     validations:
       required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,11 @@
 Rust TUI Git tool built with ratatui + git2-rs. See @README.md for details.
 See @docs/INTENT.md for the product vision (4 pillars: review-support, local-gui, automation, dev-support).
 
+## コミュニケーション
+
+- **日本語でコミュニケーションする** — Issue、PR、コミットメッセージの本文、ドキュメントは日本語で記述する
+- コミットメッセージのprefix（feat, fix等）は英語のまま使用する
+
 ## Build & Test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,76 +1,76 @@
 # reown
 
-> Own your codebase again, even in the age of agent PR storm.
+> エージェントPRの嵐の時代でも、コードベースを自分のものに。
 
-## What is reown?
+## reownとは？
 
-A TUI (terminal UI) Git tool for developers who want to stay on top of their codebase even when AI agents are generating a flood of PRs.
+AIエージェントが大量のPRを生成する時代に、コードベースを把握し続けたい開発者のためのTUI（ターミナルUI）Gitツールです。
 
-Instead of reviewing code line-by-line, reown lets you manage your worktrees, branches, and diffs from a single interactive interface — inspired by lazygit.
-
----
-
-## Features (Phase 1 — Git GUI Foundation)
-
-- **Worktree management** — list all worktrees with their branch and path; create new ones with one keystroke
-- **Branch management** — list, create, switch, and delete local branches
-- **Diff viewer** — browse changed files and view diffs with syntax-highlighted additions/deletions
+コードを1行ずつレビューする代わりに、reownではワークツリー、ブランチ、差分を単一のインタラクティブなインターフェースから管理できます。lazygitにインスパイアされています。
 
 ---
 
-## Usage
+## 機能（Phase 1 — Git GUI基盤）
+
+- **ワークツリー管理** — すべてのワークツリーをブランチとパス付きで一覧表示。ワンキーで新規作成
+- **ブランチ管理** — ローカルブランチの一覧、作成、切り替え、削除
+- **Diffビューア** — 変更ファイルを閲覧し、シンタックスハイライト付きの追加/削除差分を表示
+
+---
+
+## 使い方
 
 ```sh
-# Build
+# ビルド
 cargo build --release
 
-# Run in the current directory's repo
+# カレントディレクトリのリポジトリで実行
 ./target/release/reown
 
-# Run against a specific repo
+# 特定のリポジトリに対して実行
 ./target/release/reown /path/to/repo
 ```
 
-### Keyboard shortcuts
+### キーボードショートカット
 
-| Key | Action |
-|-----|--------|
-| `Tab` | Cycle through views (Worktrees → Branches → Diff) |
-| `w` | Go to Worktrees view |
-| `b` | Go to Branches view |
-| `d` | Go to Diff view |
-| `↑` / `k` | Move up |
-| `↓` / `j` | Move down |
-| `↵` | Switch to selected branch (Branches view) |
-| `c` | Create branch / worktree |
-| `x` / `Del` | Delete selected branch |
-| `r` | Refresh |
-| `q` / `Ctrl-C` | Quit |
+| キー | 操作 |
+|------|------|
+| `Tab` | ビューを切り替え（ワークツリー → ブランチ → Diff） |
+| `w` | ワークツリービューへ |
+| `b` | ブランチビューへ |
+| `d` | Diffビューへ |
+| `↑` / `k` | 上に移動 |
+| `↓` / `j` | 下に移動 |
+| `↵` | 選択したブランチに切り替え（ブランチビュー） |
+| `c` | ブランチ / ワークツリーを作成 |
+| `x` / `Del` | 選択したブランチを削除 |
+| `r` | リフレッシュ |
+| `q` / `Ctrl-C` | 終了 |
 
 ---
 
-## Tech Stack
+## 技術スタック
 
-- **Language**: Rust
+- **言語**: Rust
 - **TUI**: [ratatui](https://ratatui.rs) + crossterm
-- **Git**: [git2-rs](https://github.com/rust-lang/git2-rs) (libgit2 bindings)
+- **Git**: [git2-rs](https://github.com/rust-lang/git2-rs) (libgit2バインディング)
 
 ---
 
-## Roadmap
+## ロードマップ
 
-### Phase 1 — Git GUI Foundation ✅
-- [x] Worktree listing and status display
-- [x] Branch creation, switching, deletion
-- [x] Diff display (file-level and chunk-level)
-- [x] One-keystroke worktree creation
+### Phase 1 — Git GUI基盤 ✅
+- [x] ワークツリーの一覧表示とステータス表示
+- [x] ブランチの作成、切り替え、削除
+- [x] Diff表示（ファイルレベル・チャンクレベル）
+- [x] ワンキーでのワークツリー作成
 
-### Phase 2 — PR Support
-- [ ] Auto-generate PR descriptions (diff → description via AI)
-- [ ] PR list from GitHub API
-- [ ] Abstract-layer review assistance (impact range, intent summary)
+### Phase 2 — PRサポート
+- [ ] PR説明文の自動生成（diff → AI経由で説明文）
+- [ ] GitHub APIからのPRリスト取得
+- [ ] 抽象レイヤーのレビュー支援（影響範囲、意図の要約）
 
-### Phase 3 — Enhanced Developer Experience
-- [ ] Development task suggestions from codebase state
-- [ ] Agent PR triage assistance (priority, risk, impact classification)
-- [ ] Workflow customization
+### Phase 3 — 開発体験の強化
+- [ ] コードベース状態からの開発タスク提案
+- [ ] エージェントPRのトリアージ支援（優先度、リスク、影響の分類）
+- [ ] ワークフローのカスタマイズ


### PR DESCRIPTION
## Summary

Implements issue #30: ドキュメント・テンプレートの日本語化

## 概要
README.md、docs/INTENT.md以外のドキュメント、GitHub Issue テンプレート、CLAUDE.mdのユーザー向けテキストを日本語に変更する。

## 対象ファイル
- `.github/ISSUE_TEMPLATE/feature_request.yml` — ラベル・説明・フィールド名を日本語化
- `.github/ISSUE_TEMPLATE/bug_report.yml` — 同上
- `.github/ISSUE_TEMPLATE/config.yml` — 日本語化
- `README.md` — 日本語版に書き換え（使い方、キーボードショートカット表、ロードマップ等）
- `CLAUDE.md` — 日本語でのコミュニケーションルールを追記
- `.claude/rules/git.md` — コミットメッセージルールの日本語補足

## 受け入れ基準
- [ ] Issue テンプレート（feature_request.yml, bug_report.yml, config.yml）が日本語になっている
- [ ] README.mdが日本語で記述されている
- [ ] CLAUDE.mdに「日本語でコミュニケーションする」旨のルールが追加されている
- [ ] ソースコードは変更しない

Parent: #16

Closes #30

---
Generated by agent/loop.sh