### PR TITLE
feat: TUIテキストのi18n基盤構築と日本語化

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use crate::git::{
     worktree::{self, WorktreeInfo},
 };
 use crate::github::PrInfo;
+use crate::i18n;
 use anyhow::Result;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -227,15 +228,15 @@ impl App {
     pub fn confirm_create_branch(&mut self) {
         let name = self.input_buf.trim().to_string();
         if name.is_empty() {
-            self.status_msg = Some("Branch name cannot be empty.".into());
+            self.status_msg = Some(i18n::BRANCH_NAME_EMPTY.into());
         } else {
             match branch::create_branch(&self.repo_path, &name) {
                 Ok(()) => {
-                    self.status_msg = Some(format!("Branch '{name}' created."));
+                    self.status_msg = Some(i18n::branch_created(&name));
                     self.refresh();
                 }
                 Err(e) => {
-                    self.status_msg = Some(format!("Error: {e}"));
+                    self.status_msg = Some(i18n::error_msg(&e));
                 }
             }
         }
@@ -249,11 +250,11 @@ impl App {
             let name = b.name.clone();
             match branch::switch_branch(&self.repo_path, &name) {
                 Ok(()) => {
-                    self.status_msg = Some(format!("Switched to '{name}'."));
+                    self.status_msg = Some(i18n::branch_switched(&name));
                     self.refresh();
                 }
                 Err(e) => {
-                    self.status_msg = Some(format!("Error: {e}"));
+                    self.status_msg = Some(i18n::error_msg(&e));
                 }
             }
         }
@@ -265,11 +266,11 @@ impl App {
             let name = b.name.clone();
             match branch::delete_branch(&self.repo_path, &name) {
                 Ok(()) => {
-                    self.status_msg = Some(format!("Branch '{name}' deleted."));
+                    self.status_msg = Some(i18n::branch_deleted(&name));
                     self.refresh();
                 }
                 Err(e) => {
-                    self.status_msg = Some(format!("Error: {e}"));
+                    self.status_msg = Some(i18n::error_msg(&e));
                 }
             }
         }
@@ -282,17 +283,17 @@ impl App {
         let raw = self.input_buf.trim().to_string();
         let parts: Vec<&str> = raw.splitn(2, '|').collect();
         if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
-            self.status_msg = Some("Format: <path>|<branch>".into());
+            self.status_msg = Some(i18n::WORKTREE_FORMAT_HINT.into());
         } else {
             let wt_path = parts[0].trim();
             let branch = parts[1].trim();
             match worktree::add_worktree(&self.repo_path, wt_path, branch) {
                 Ok(()) => {
-                    self.status_msg = Some(format!("Worktree '{branch}' added at '{wt_path}'."));
+                    self.status_msg = Some(i18n::worktree_added(wt_path, branch));
                     self.refresh();
                 }
                 Err(e) => {
-                    self.status_msg = Some(format!("Error: {e}"));
+                    self.status_msg = Some(i18n::error_msg(&e));
                 }
             }
         }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,60 @@
+//! UI テキスト定数モジュール
+//!
+//! アプリケーション内の全UIテキストをこのモジュールに集約する。
+//! 現段階では日本語のみ。将来的にlocale切り替え可能な設計にする。
+
+// ── ヘッダー ─────────────────────────────────────────────────────────────
+pub const HEADER_APP_NAME: &str = " reown  ";
+pub const HEADER_TAB_WORKTREES: &str = " [w] ワークツリー ";
+pub const HEADER_TAB_BRANCHES: &str = " [b] ブランチ ";
+pub const HEADER_TAB_DIFF: &str = " [d] 差分 ";
+pub const HEADER_TAB_PRS: &str = " [p] PR ";
+pub const HEADER_HELP: &str = "  ─  Tab:次へ  q:終了  r:更新";
+
+// ── ステータスバー ───────────────────────────────────────────────────────
+pub const STATUS_DEFAULT: &str =
+    "q:終了  Tab:ビュー切替  ↑↓:移動  c:作成  x/Del:削除  ↵:確定";
+pub const STATUS_INPUT_PROMPT: &str = "入力:";
+pub const STATUS_REFRESHED: &str = "更新しました";
+
+// ── ブランチ ─────────────────────────────────────────────────────────────
+pub const BRANCH_TITLE: &str = " ブランチ [b]  (c)作成  (x)削除  (↵)切替 ";
+pub const BRANCH_PROMPT_NEW: &str = "新しいブランチ名 (Enter で確定、Esc でキャンセル):";
+pub const BRANCH_NAME_EMPTY: &str = "ブランチ名を入力してください";
+
+pub fn branch_created(name: &str) -> String {
+    format!("ブランチ '{name}' を作成しました")
+}
+
+pub fn branch_switched(name: &str) -> String {
+    format!("ブランチ '{name}' に切り替えました")
+}
+
+pub fn branch_deleted(name: &str) -> String {
+    format!("ブランチ '{name}' を削除しました")
+}
+
+// ── ワークツリー ─────────────────────────────────────────────────────────
+pub const WORKTREE_TITLE: &str = " ワークツリー [w] ";
+pub const WORKTREE_DETACHED_HEAD: &str = "(デタッチド HEAD)";
+pub const WORKTREE_PROMPT_NEW: &str =
+    "新しいワークツリー パス|ブランチ (Enter で確定、Esc でキャンセル):";
+pub const WORKTREE_FORMAT_HINT: &str = "形式: <パス>|<ブランチ>";
+
+pub fn worktree_added(wt_path: &str, branch: &str) -> String {
+    format!("ワークツリー '{branch}' を '{wt_path}' に追加しました")
+}
+
+// ── Diff ─────────────────────────────────────────────────────────────────
+pub const DIFF_FILES_TITLE: &str = " ファイル ";
+pub const DIFF_CONTENT_TITLE: &str = " 差分  (↑↓)スクロール  [d] ";
+pub const DIFF_NO_FILE_SELECTED: &str = "(ファイル未選択)";
+pub const DIFF_UNKNOWN_PATH: &str = "(不明)";
+
+// ── プルリクエスト ───────────────────────────────────────────────────────
+pub const PR_TITLE: &str = " プルリクエスト [p] ";
+
+// ── エラー ───────────────────────────────────────────────────────────────
+pub fn error_msg(e: &impl std::fmt::Display) -> String {
+    format!("エラー: {e}")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod git;
 mod github;
+mod i18n;
 mod ui;
 
 use app::{App, InputMode, View};
@@ -137,24 +138,19 @@ fn run_app(
                     // Refresh
                     KeyCode::Char('r') => {
                         app.refresh();
-                        app.status_msg = Some("Refreshed.".into());
+                        app.status_msg = Some(i18n::STATUS_REFRESHED.into());
                     }
                     // Actions
                     KeyCode::Char('c') => match app.view {
                         View::Branches => {
                             app.input_mode = InputMode::NewBranch;
                             app.input_buf.clear();
-                            app.status_msg = Some(
-                                "New branch name (Enter to confirm, Esc to cancel):".into(),
-                            );
+                            app.status_msg = Some(i18n::BRANCH_PROMPT_NEW.into());
                         }
                         View::Worktrees => {
                             app.input_mode = InputMode::NewWorktree;
                             app.input_buf.clear();
-                            app.status_msg = Some(
-                                "New worktree  path|branch  (Enter to confirm, Esc to cancel):"
-                                    .into(),
-                            );
+                            app.status_msg = Some(i18n::WORKTREE_PROMPT_NEW.into());
                         }
                         View::Diff | View::PullRequests => {}
                     },
@@ -202,15 +198,15 @@ fn draw(frame: &mut ratatui::Frame, app: &App) {
         }
     };
     let header = Line::from(vec![
-        Span::raw(" reown  "),
-        Span::styled(" [w] Worktrees ", tab_style(View::Worktrees)),
+        Span::raw(i18n::HEADER_APP_NAME),
+        Span::styled(i18n::HEADER_TAB_WORKTREES, tab_style(View::Worktrees)),
         Span::raw(" "),
-        Span::styled(" [b] Branches ", tab_style(View::Branches)),
+        Span::styled(i18n::HEADER_TAB_BRANCHES, tab_style(View::Branches)),
         Span::raw(" "),
-        Span::styled(" [d] Diff ", tab_style(View::Diff)),
+        Span::styled(i18n::HEADER_TAB_DIFF, tab_style(View::Diff)),
         Span::raw(" "),
-        Span::styled(" [p] PRs ", tab_style(View::PullRequests)),
-        Span::raw("  ─  Tab:next  q:quit  r:refresh"),
+        Span::styled(i18n::HEADER_TAB_PRS, tab_style(View::PullRequests)),
+        Span::raw(i18n::HEADER_HELP),
     ]);
     frame.render_widget(
         Paragraph::new(header).style(Style::default().bg(Color::DarkGray)),
@@ -261,13 +257,14 @@ fn draw(frame: &mut ratatui::Frame, app: &App) {
     // ── Status bar / input ────────────────────────────────────────────────
     let status_content = match app.input_mode {
         InputMode::Normal => {
-            let msg = app.status_msg.as_deref().unwrap_or(
-                "q:quit  Tab:switch view  ↑↓:navigate  c:create  x/Del:delete  ↵:confirm",
-            );
+            let msg = app
+                .status_msg
+                .as_deref()
+                .unwrap_or(i18n::STATUS_DEFAULT);
             Line::from(Span::styled(msg, Style::default().fg(Color::White)))
         }
         InputMode::NewBranch | InputMode::NewWorktree => {
-            let prompt = app.status_msg.as_deref().unwrap_or("Input:");
+            let prompt = app.status_msg.as_deref().unwrap_or(i18n::STATUS_INPUT_PROMPT);
             Line::from(vec![
                 Span::styled(format!("{prompt} "), Style::default().fg(Color::Yellow)),
                 Span::styled(app.input_buf.clone(), Style::default().fg(Color::White)),

--- a/src/ui/branch.rs
+++ b/src/ui/branch.rs
@@ -1,4 +1,5 @@
 use crate::git::branch::BranchInfo;
+use crate::i18n;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -50,7 +51,7 @@ pub fn render_branches(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(" Branches [b]  (c)reate  (x)delete  (↵)switch ")
+                .title(i18n::BRANCH_TITLE)
                 .borders(Borders::ALL)
                 .border_style(border_style),
         )

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -1,4 +1,5 @@
 use crate::git::diff::{FileDiff, FileStatus, LineOrigin};
+use crate::i18n;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -43,7 +44,7 @@ pub fn render_diff(
                 .new_path
                 .as_deref()
                 .or(fd.old_path.as_deref())
-                .unwrap_or("(unknown)");
+                .unwrap_or(i18n::DIFF_UNKNOWN_PATH);
             let line = Line::from(vec![
                 Span::styled(
                     format!("[{status_char}] "),
@@ -65,7 +66,7 @@ pub fn render_diff(
     let file_list = List::new(file_items)
         .block(
             Block::default()
-                .title(" Files ")
+                .title(i18n::DIFF_FILES_TITLE)
                 .borders(Borders::ALL)
                 .border_style(border_style),
         )
@@ -112,7 +113,7 @@ pub fn render_diff(
             .collect()
     } else {
         vec![Line::from(Span::styled(
-            "(no file selected)",
+            i18n::DIFF_NO_FILE_SELECTED,
             Style::default().fg(Color::DarkGray),
         ))]
     };
@@ -122,7 +123,7 @@ pub fn render_diff(
     let diff_para = Paragraph::new(diff_lines)
         .block(
             Block::default()
-                .title(" Diff  (↑↓)scroll  [d] ")
+                .title(i18n::DIFF_CONTENT_TITLE)
                 .borders(Borders::ALL)
                 .border_style(border_style),
         )

--- a/src/ui/pull_request.rs
+++ b/src/ui/pull_request.rs
@@ -1,4 +1,5 @@
 use crate::github::PrInfo;
+use crate::i18n;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -55,7 +56,7 @@ pub fn render_pull_requests(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(" Pull Requests [p] ")
+                .title(i18n::PR_TITLE)
                 .borders(Borders::ALL)
                 .border_style(border_style),
         )

--- a/src/ui/worktree.rs
+++ b/src/ui/worktree.rs
@@ -1,4 +1,5 @@
 use crate::git::worktree::WorktreeInfo;
+use crate::i18n;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -28,7 +29,7 @@ pub fn render_worktrees(
             let branch_label = wt
                 .branch
                 .as_deref()
-                .unwrap_or("(detached HEAD)");
+                .unwrap_or(i18n::WORKTREE_DETACHED_HEAD);
             let path_str = wt.path.to_string_lossy();
             let display_name = if wt.name.len() > 24 {
                 format!("{}…", &wt.name[..23])
@@ -56,7 +57,7 @@ pub fn render_worktrees(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(" Worktrees [w] ")
+                .title(i18n::WORKTREE_TITLE)
                 .borders(Borders::ALL)
                 .border_style(border_style),
         )


### PR DESCRIPTION
## Summary

Implements issue #31: TUIテキストのi18n基盤構築と日本語化

## 概要
アプリケーション内のUIテキスト（ステータスバー、ヘッダー、操作説明等）を日本語化する。将来的な多言語対応を見据えて、テキストを定数またはシンプルなモジュールに集約する仕組みを導入する。

## 対象ファイル
- `src/ui/branch.rs` — タイトル、操作説明テキスト
- `src/ui/diff.rs` — タイトル、ステータステキスト
- `src/ui/worktree.rs` — タイトル、ステータステキスト
- `src/ui/pull_request.rs` — タイトル、ステータステキスト
- `src/main.rs` — ヘッダー、ステータスバーのテキスト
- 新規: `src/i18n.rs`（または`src/text.rs`）— UIテキスト定数を集約するモジュール

## 設計方針
- シンプルに定数モジュール（`src/i18n.rs`）にUI文字列を集約
- 現段階では日本語のみでOK。将来的にlocale切り替え可能な設計にしておく
- 外部crateは不要（定数 or static strで十分）

## 受け入れ基準
- [ ] UIテキストが日本語で表示される
- [ ] テキスト定数が1つのモジュールに集約されている
- [ ] `cargo test` が通る
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #16

Closes #31

---
Generated by agent/loop.sh