### PR TITLE
fix: progress.txt が無限に肥大化

### DIFF
--- a/agent/lib/00_config.sh
+++ b/agent/lib/00_config.sh
@@ -13,3 +13,5 @@ CI_INITIAL_WAIT="${CI_INITIAL_WAIT:-60}"        # seconds to wait before first C
 CI_POLL_INTERVAL="${CI_POLL_INTERVAL:-30}"      # seconds between CI status polls
 CI_POLL_TIMEOUT="${CI_POLL_TIMEOUT:-600}"       # max seconds for one polling window (default 10min)
 PROPOSE_MAX_TURNS="${PROPOSE_MAX_TURNS:-10}"
+LOG_MAX_BYTES="${LOG_MAX_BYTES:-524288}"       # 512KB per file
+LOG_MAX_FILES="${LOG_MAX_FILES:-3}"             # keep progress.txt + 3 archives

--- a/agent/lib/10_log.sh
+++ b/agent/lib/10_log.sh
@@ -1,7 +1,35 @@
-# agent/lib/10_log.sh — Logging helper
+# agent/lib/10_log.sh — Logging helper with rotation
+
+_log_file="$REPO_ROOT/progress.txt"
+
+# Rotate progress.txt when it exceeds LOG_MAX_BYTES.
+# Keeps up to LOG_MAX_FILES archived copies (.1, .2, …).
+_rotate_log() {
+  [[ -f "$_log_file" ]] || return 0
+  local size
+  size=$(wc -c < "$_log_file" 2>/dev/null || echo 0)
+  if [[ "$size" -lt "${LOG_MAX_BYTES:-524288}" ]]; then
+    return 0
+  fi
+
+  local max="${LOG_MAX_FILES:-3}"
+  # Remove the oldest archive if it exists
+  rm -f "${_log_file}.${max}"
+  # Shift archives: .2 → .3, .1 → .2, etc.
+  local i=$((max - 1))
+  while [[ "$i" -ge 1 ]]; do
+    if [[ -f "${_log_file}.${i}" ]]; then
+      mv "${_log_file}.${i}" "${_log_file}.$((i + 1))"
+    fi
+    i=$((i - 1))
+  done
+  # Current → .1
+  mv "$_log_file" "${_log_file}.1"
+}
 
 log() {
   local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
   echo "$msg"
-  echo "$msg" >> "$REPO_ROOT/progress.txt"
+  _rotate_log
+  echo "$msg" >> "$_log_file"
 }

--- a/agent/tests/test_log_rotation.sh
+++ b/agent/tests/test_log_rotation.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# agent/tests/test_log_rotation.sh — Tests for log rotation
+set -euo pipefail
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+# ── Setup temp dir as REPO_ROOT ─────────────────────────────────────────────
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+export REPO_ROOT="$TMPDIR_ROOT"
+
+# Source config defaults, then the log library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/lib/00_config.sh"
+source "$SCRIPT_DIR/lib/10_log.sh"
+
+# ── Test 1: log creates progress.txt ─────────────────────────────────────────
+log "hello" > /dev/null
+if [[ -f "$REPO_ROOT/progress.txt" ]]; then
+  pass "log creates progress.txt"
+else
+  fail "log creates progress.txt"
+fi
+
+# ── Test 2: log appends to progress.txt ──────────────────────────────────────
+log "world" > /dev/null
+lines=$(wc -l < "$REPO_ROOT/progress.txt")
+if [[ "$lines" -eq 2 ]]; then
+  pass "log appends lines"
+else
+  fail "log appends lines (expected 2, got $lines)"
+fi
+
+# ── Test 3: no rotation when under limit ─────────────────────────────────────
+if [[ ! -f "$REPO_ROOT/progress.txt.1" ]]; then
+  pass "no rotation under limit"
+else
+  fail "no rotation under limit (found progress.txt.1)"
+fi
+
+# ── Test 4: rotation triggers when over limit ────────────────────────────────
+rm -f "$REPO_ROOT"/progress.txt*
+export LOG_MAX_BYTES=100
+# Write enough data to exceed 100 bytes
+for i in $(seq 1 5); do
+  log "padding line $i with extra text to fill up the file quickly" > /dev/null
+done
+if [[ -f "$REPO_ROOT/progress.txt.1" ]]; then
+  pass "rotation triggers on size limit"
+else
+  fail "rotation triggers on size limit (progress.txt.1 not found)"
+fi
+
+# ── Test 5: current progress.txt is small after rotation ─────────────────────
+current_size=$(wc -c < "$REPO_ROOT/progress.txt")
+if [[ "$current_size" -lt 100 ]]; then
+  pass "current file is small after rotation"
+else
+  fail "current file is small after rotation (size=$current_size)"
+fi
+
+# ── Test 6: max archives respected ───────────────────────────────────────────
+rm -f "$REPO_ROOT"/progress.txt*
+export LOG_MAX_BYTES=50
+export LOG_MAX_FILES=2
+# Re-source to pick up new _log_file (REPO_ROOT didn't change, but ensure fresh state)
+source "$SCRIPT_DIR/lib/10_log.sh"
+
+for i in $(seq 1 30); do
+  log "fill line $i with padding to trigger multiple rotations" > /dev/null
+done
+
+if [[ ! -f "$REPO_ROOT/progress.txt.3" ]]; then
+  pass "max archives respected (no .3 with LOG_MAX_FILES=2)"
+else
+  fail "max archives respected (found progress.txt.3)"
+fi
+
+if [[ -f "$REPO_ROOT/progress.txt.1" ]]; then
+  pass "archive .1 exists"
+else
+  fail "archive .1 exists"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "$FAILURES test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Implements issue #43: progress.txt が無限に肥大化

課題を解消して

全ログが appendされるだけで、ローテーションや最大サイズ制限がありません。長期運用でディスクを圧迫します。

Closes #43

---
Generated by agent/loop.sh