### PR TITLE
feat: GUI: Worktree・Branch管理画面の実装

### DIFF
--- a/src-frontend/src/index.html
+++ b/src-frontend/src/index.html
@@ -8,9 +8,65 @@
 </head>
 <body>
   <div id="app">
-    <h1>Hello reown</h1>
-    <p>エージェントPRの嵐の時代でも、コードベースを自分のものに。</p>
-    <div id="branches"></div>
+    <header class="app-header">
+      <h1>reown</h1>
+      <p class="tagline">エージェントPRの嵐の時代でも、コードベースを自分のものに。</p>
+    </header>
+
+    <div class="panels">
+      <!-- Worktree管理パネル -->
+      <section class="panel" id="worktree-panel">
+        <h2>ワークツリー</h2>
+        <div id="worktree-list" class="list-container">
+          <p class="loading">読み込み中…</p>
+        </div>
+        <div class="form-section">
+          <h3>新規ワークツリー作成</h3>
+          <form id="worktree-form">
+            <div class="form-group">
+              <label for="wt-path">パス</label>
+              <input type="text" id="wt-path" placeholder="/path/to/worktree" required>
+            </div>
+            <div class="form-group">
+              <label for="wt-branch">ブランチ名</label>
+              <input type="text" id="wt-branch" placeholder="feature-branch" required>
+            </div>
+            <button type="submit" class="btn btn-primary">作成</button>
+          </form>
+          <div id="worktree-message" class="message"></div>
+        </div>
+      </section>
+
+      <!-- Branch管理パネル -->
+      <section class="panel" id="branch-panel">
+        <h2>ブランチ</h2>
+        <div id="branch-list" class="list-container">
+          <p class="loading">読み込み中…</p>
+        </div>
+        <div class="form-section">
+          <h3>新規ブランチ作成</h3>
+          <form id="branch-form">
+            <div class="form-group">
+              <label for="branch-name">ブランチ名</label>
+              <input type="text" id="branch-name" placeholder="new-branch" required>
+            </div>
+            <button type="submit" class="btn btn-primary">作成</button>
+          </form>
+          <div id="branch-message" class="message"></div>
+        </div>
+      </section>
+    </div>
+
+    <!-- 削除確認ダイアログ -->
+    <div id="confirm-dialog" class="dialog-overlay" hidden>
+      <div class="dialog">
+        <p id="confirm-message"></p>
+        <div class="dialog-actions">
+          <button id="confirm-cancel" class="btn btn-secondary">キャンセル</button>
+          <button id="confirm-ok" class="btn btn-danger">削除</button>
+        </div>
+      </div>
+    </div>
   </div>
   <script src="main.js"></script>
 </body>

--- a/src-frontend/src/main.js
+++ b/src-frontend/src/main.js
@@ -1,29 +1,255 @@
-// Tauri APIが利用可能な場合、ブランチ一覧を取得して表示する
-async function loadBranches() {
-  const container = document.getElementById("branches");
-  if (!window.__TAURI__) {
-    container.innerHTML = "<p>Tauri API not available (running in browser)</p>";
-    return;
-  }
+// ── Tauri invoke ヘルパー ───────────────────────────────────────────
 
+async function invoke(command, args) {
+  if (!window.__TAURI__) {
+    throw new Error("Tauri API not available (running in browser)");
+  }
+  return window.__TAURI__.core.invoke(command, args);
+}
+
+// ── Worktree管理 ───────────────────────────────────────────────────
+
+async function loadWorktrees() {
+  const container = document.getElementById("worktree-list");
   try {
-    const { invoke } = window.__TAURI__.core;
-    const branches = await invoke("list_branches");
-    if (branches.length === 0) {
-      container.innerHTML = "<p>No branches found.</p>";
+    const worktrees = await invoke("list_worktrees");
+    if (worktrees.length === 0) {
+      container.innerHTML = '<p class="empty">ワークツリーがありません。</p>';
       return;
     }
-    const ul = document.createElement("ul");
-    for (const b of branches) {
-      const li = document.createElement("li");
-      li.textContent = b.is_head ? `* ${b.name}` : `  ${b.name}`;
-      if (b.is_head) li.classList.add("head");
-      ul.appendChild(li);
+    container.innerHTML = "";
+    for (const wt of worktrees) {
+      const div = document.createElement("div");
+      div.className = "wt-item";
+
+      let nameHtml = `<span class="wt-name${wt.is_main ? " main" : ""}">${escapeHtml(wt.name)}</span>`;
+      if (wt.is_locked) {
+        nameHtml += '<span class="wt-badge locked">locked</span>';
+      }
+
+      const branch = wt.branch ? escapeHtml(wt.branch) : "(detached)";
+      const path = escapeHtml(wt.path);
+
+      div.innerHTML = `
+        ${nameHtml}
+        <div class="wt-detail">ブランチ: ${branch}</div>
+        <div class="wt-detail">パス: ${path}</div>
+      `;
+      container.appendChild(div);
     }
-    container.appendChild(ul);
   } catch (err) {
-    container.innerHTML = `<p>Error: ${err}</p>`;
+    container.innerHTML = `<p class="error">エラー: ${escapeHtml(String(err))}</p>`;
   }
 }
 
-document.addEventListener("DOMContentLoaded", loadBranches);
+function setupWorktreeForm() {
+  const form = document.getElementById("worktree-form");
+  const msg = document.getElementById("worktree-message");
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const pathInput = document.getElementById("wt-path");
+    const branchInput = document.getElementById("wt-branch");
+    const submitBtn = form.querySelector('button[type="submit"]');
+
+    const wtPath = pathInput.value.trim();
+    const branch = branchInput.value.trim();
+    if (!wtPath || !branch) return;
+
+    submitBtn.disabled = true;
+    msg.textContent = "";
+    msg.className = "message";
+
+    try {
+      await invoke("add_worktree", { worktreePath: wtPath, branch: branch });
+      msg.textContent = "ワークツリーを作成しました。";
+      msg.className = "message success";
+      pathInput.value = "";
+      branchInput.value = "";
+      await loadWorktrees();
+    } catch (err) {
+      msg.textContent = `エラー: ${err}`;
+      msg.className = "message error";
+    } finally {
+      submitBtn.disabled = false;
+    }
+  });
+}
+
+// ── Branch管理 ────────────────────────────────────────────────────
+
+async function loadBranches() {
+  const container = document.getElementById("branch-list");
+  try {
+    const branches = await invoke("list_branches");
+    if (branches.length === 0) {
+      container.innerHTML = '<p class="empty">ブランチがありません。</p>';
+      return;
+    }
+    container.innerHTML = "";
+    for (const b of branches) {
+      const div = document.createElement("div");
+      div.className = "branch-item";
+
+      const infoDiv = document.createElement("div");
+      infoDiv.className = "branch-info";
+
+      const nameSpan = document.createElement("div");
+      nameSpan.className = `branch-name${b.is_head ? " head" : ""}`;
+      nameSpan.textContent = b.is_head ? `* ${b.name}` : b.name;
+      infoDiv.appendChild(nameSpan);
+
+      if (b.upstream) {
+        const upstreamDiv = document.createElement("div");
+        upstreamDiv.className = "branch-upstream";
+        upstreamDiv.textContent = `upstream: ${b.upstream}`;
+        infoDiv.appendChild(upstreamDiv);
+      }
+
+      div.appendChild(infoDiv);
+
+      // アクションボタン（HEADブランチ以外に表示）
+      if (!b.is_head) {
+        const actionsDiv = document.createElement("div");
+        actionsDiv.className = "branch-actions";
+
+        const switchBtn = document.createElement("button");
+        switchBtn.className = "btn btn-secondary btn-small";
+        switchBtn.textContent = "切替";
+        switchBtn.addEventListener("click", () => handleSwitchBranch(b.name));
+        actionsDiv.appendChild(switchBtn);
+
+        const deleteBtn = document.createElement("button");
+        deleteBtn.className = "btn btn-danger btn-small";
+        deleteBtn.textContent = "削除";
+        deleteBtn.addEventListener("click", () => handleDeleteBranch(b.name));
+        actionsDiv.appendChild(deleteBtn);
+
+        div.appendChild(actionsDiv);
+      }
+
+      container.appendChild(div);
+    }
+  } catch (err) {
+    container.innerHTML = `<p class="error">エラー: ${escapeHtml(String(err))}</p>`;
+  }
+}
+
+function setupBranchForm() {
+  const form = document.getElementById("branch-form");
+  const msg = document.getElementById("branch-message");
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const nameInput = document.getElementById("branch-name");
+    const submitBtn = form.querySelector('button[type="submit"]');
+
+    const name = nameInput.value.trim();
+    if (!name) return;
+
+    submitBtn.disabled = true;
+    msg.textContent = "";
+    msg.className = "message";
+
+    try {
+      await invoke("create_branch", { name: name });
+      msg.textContent = `ブランチ '${name}' を作成しました。`;
+      msg.className = "message success";
+      nameInput.value = "";
+      await loadBranches();
+    } catch (err) {
+      msg.textContent = `エラー: ${err}`;
+      msg.className = "message error";
+    } finally {
+      submitBtn.disabled = false;
+    }
+  });
+}
+
+async function handleSwitchBranch(name) {
+  const msg = document.getElementById("branch-message");
+  msg.textContent = "";
+  msg.className = "message";
+
+  try {
+    await invoke("switch_branch", { name: name });
+    msg.textContent = `ブランチ '${name}' に切り替えました。`;
+    msg.className = "message success";
+    await loadBranches();
+    await loadWorktrees();
+  } catch (err) {
+    msg.textContent = `エラー: ${err}`;
+    msg.className = "message error";
+  }
+}
+
+async function handleDeleteBranch(name) {
+  const confirmed = await showConfirmDialog(
+    `ブランチ '${name}' を削除しますか？この操作は取り消せません。`
+  );
+  if (!confirmed) return;
+
+  const msg = document.getElementById("branch-message");
+  msg.textContent = "";
+  msg.className = "message";
+
+  try {
+    await invoke("delete_branch", { name: name });
+    msg.textContent = `ブランチ '${name}' を削除しました。`;
+    msg.className = "message success";
+    await loadBranches();
+  } catch (err) {
+    msg.textContent = `エラー: ${err}`;
+    msg.className = "message error";
+  }
+}
+
+// ── 確認ダイアログ ─────────────────────────────────────────────────
+
+function showConfirmDialog(message) {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById("confirm-dialog");
+    const msgEl = document.getElementById("confirm-message");
+    const cancelBtn = document.getElementById("confirm-cancel");
+    const okBtn = document.getElementById("confirm-ok");
+
+    msgEl.textContent = message;
+    overlay.hidden = false;
+
+    function cleanup() {
+      overlay.hidden = true;
+      cancelBtn.removeEventListener("click", onCancel);
+      okBtn.removeEventListener("click", onOk);
+    }
+
+    function onCancel() {
+      cleanup();
+      resolve(false);
+    }
+
+    function onOk() {
+      cleanup();
+      resolve(true);
+    }
+
+    cancelBtn.addEventListener("click", onCancel);
+    okBtn.addEventListener("click", onOk);
+  });
+}
+
+// ── ユーティリティ ──────────────────────────────────────────────────
+
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+// ── 初期化 ─────────────────────────────────────────────────────────
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupWorktreeForm();
+  setupBranchForm();
+  loadWorktrees();
+  loadBranches();
+});

--- a/src-frontend/src/style.css
+++ b/src-frontend/src/style.css
@@ -9,47 +9,335 @@ body {
     Ubuntu, Cantarell, sans-serif;
   background-color: #1a1a2e;
   color: #e0e0e0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   min-height: 100vh;
 }
 
 #app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+/* ── Header ─────────────────────────────────────────────────────── */
+
+.app-header {
   text-align: center;
-  padding: 2rem;
-}
-
-h1 {
-  font-size: 2.5rem;
-  margin-bottom: 0.5rem;
-  color: #ffffff;
-}
-
-p {
-  font-size: 1.1rem;
-  color: #a0a0b0;
   margin-bottom: 2rem;
 }
 
-#branches {
-  text-align: left;
-  max-width: 400px;
-  margin: 0 auto;
+.app-header h1 {
+  font-size: 2rem;
+  color: #ffffff;
+  margin-bottom: 0.25rem;
 }
 
-#branches ul {
-  list-style: none;
+.tagline {
+  font-size: 0.95rem;
+  color: #a0a0b0;
 }
 
-#branches li {
-  padding: 0.4rem 0.8rem;
+/* ── Panels layout ──────────────────────────────────────────────── */
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.panel {
+  background-color: #16213e;
+  border: 1px solid #2a2a3e;
+  border-radius: 8px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel h2 {
+  font-size: 1.2rem;
+  color: #ffffff;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #2a2a3e;
+}
+
+/* ── List container ─────────────────────────────────────────────── */
+
+.list-container {
+  flex: 1;
+  min-height: 120px;
+  max-height: 360px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.list-container .loading {
+  color: #a0a0b0;
+  font-size: 0.9rem;
+  padding: 0.5rem;
+}
+
+.list-container .error {
+  color: #e06c75;
+  font-size: 0.9rem;
+  padding: 0.5rem;
+}
+
+.list-container .empty {
+  color: #a0a0b0;
+  font-size: 0.9rem;
+  padding: 0.5rem;
+  font-style: italic;
+}
+
+/* ── Worktree list items ────────────────────────────────────────── */
+
+.wt-item {
+  padding: 0.6rem 0.75rem;
   border-bottom: 1px solid #2a2a3e;
   font-family: "SF Mono", "Fira Code", monospace;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
-#branches li.head {
+.wt-item:last-child {
+  border-bottom: none;
+}
+
+.wt-name {
+  font-weight: bold;
+  color: #e0e0e0;
+}
+
+.wt-name.main {
+  color: #4ec9b0;
+}
+
+.wt-detail {
+  color: #a0a0b0;
+  font-size: 0.8rem;
+  margin-top: 0.2rem;
+}
+
+.wt-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  margin-left: 0.5rem;
+}
+
+.wt-badge.locked {
+  background-color: #e06c75;
+  color: #ffffff;
+}
+
+/* ── Branch list items ──────────────────────────────────────────── */
+
+.branch-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #2a2a3e;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+}
+
+.branch-item:last-child {
+  border-bottom: none;
+}
+
+.branch-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.branch-name {
+  color: #e0e0e0;
+}
+
+.branch-name.head {
   color: #4ec9b0;
   font-weight: bold;
+}
+
+.branch-upstream {
+  color: #a0a0b0;
+  font-size: 0.75rem;
+  margin-top: 0.15rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-actions {
+  display: flex;
+  gap: 0.4rem;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* ── Buttons ────────────────────────────────────────────────────── */
+
+.btn {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background-color: #4ec9b0;
+  color: #1a1a2e;
+  font-weight: 600;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #3db89f;
+}
+
+.btn-secondary {
+  background-color: #3a3a5e;
+  color: #e0e0e0;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #4a4a6e;
+}
+
+.btn-danger {
+  background-color: #e06c75;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background-color: #c85a63;
+}
+
+.btn-small {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+/* ── Forms ───────────────────────────────────────────────────────── */
+
+.form-section {
+  border-top: 1px solid #2a2a3e;
+  padding-top: 1rem;
+}
+
+.form-section h3 {
+  font-size: 0.9rem;
+  color: #c0c0d0;
+  margin-bottom: 0.75rem;
+}
+
+.form-group {
+  margin-bottom: 0.6rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: 0.8rem;
+  color: #a0a0b0;
+  margin-bottom: 0.2rem;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  background-color: #1a1a2e;
+  border: 1px solid #3a3a5e;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #4ec9b0;
+}
+
+.form-group input::placeholder {
+  color: #5a5a7e;
+}
+
+/* ── Messages ───────────────────────────────────────────────────── */
+
+.message {
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+  min-height: 1.2em;
+}
+
+.message.success {
+  color: #4ec9b0;
+}
+
+.message.error {
+  color: #e06c75;
+}
+
+/* ── Confirm dialog ─────────────────────────────────────────────── */
+
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.dialog-overlay[hidden] {
+  display: none;
+}
+
+.dialog {
+  background-color: #16213e;
+  border: 1px solid #2a2a3e;
+  border-radius: 8px;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 90%;
+}
+
+.dialog p {
+  color: #e0e0e0;
+  font-size: 0.95rem;
+  margin-bottom: 1.25rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+/* ── Scrollbar ──────────────────────────────────────────────────── */
+
+.list-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.list-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.list-container::-webkit-scrollbar-thumb {
+  background-color: #3a3a5e;
+  border-radius: 3px;
 }


### PR DESCRIPTION
## Summary

Implements issue #46: GUI: Worktree・Branch管理画面の実装

## 概要
フロントエンド（Next.js）にWorktree一覧・作成画面とBranch管理画面（一覧・作成・切替・削除）を実装する。

## 前提
- Tauriコマンド（list_worktrees, add_worktree, list_branches, create_branch, switch_branch, delete_branch）が実装済みであること

## 作業内容
- Worktree管理コンポーネント:
  - ワークツリー一覧表示（パス、ブランチ名、HEAD表示）
  - 新規ワークツリー作成フォーム
- Branch管理コンポーネント:
  - ブランチ一覧表示（現在のブランチをハイライト、upstream情報）
  - ブランチ作成フォーム
  - ブランチ切替ボタン
  - ブランチ削除ボタン（確認ダイアログ付き）
- Tauriコマンド呼び出しのhooks/ユーティリティ

## 受け入れ基準
- [ ] ワークツリーの一覧表示・作成がGUIから実行できる
- [ ] ブランチの作成・切替・削除がGUIから実行できる
- [ ] `cargo test`が通る
- [ ] `cargo clippy --all-targets -- -D warnings`が通る

Parent: #33

Closes #46

---
Generated by agent/loop.sh