### PR TITLE
refactor: CLAUDE.md とプロンプトの冗長性

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,17 +60,7 @@ src-frontend/               — Web frontend (HTML/CSS/JS)
 5. Add frontend UI in `src-frontend/src/`
 6. Write tests using tempfile pattern
 
-## Autonomous Agent Rules
+## Autonomous Agent
 
-When running as an autonomous agent (via `agent/loop.sh`):
-
-- **Task source** — GitHub issues with `agent` label (not prd.json)
-- **Label workflow** — `agent` → `planned` → `doing` → `done`
-- **One task per iteration** — implement exactly one GitHub issue per run
-- **Never modify progress.txt** — only loop.sh appends entries
-- **Tests are mandatory** — `cargo test` must pass before committing
-- **Clippy must pass** — `cargo clippy --all-targets -- -D warnings`
-- **Fix code, not tests** — if tests fail, fix the implementation
-- **Conventional Commits** — see `.claude/rules/git.md`
-- **Branch naming** — `agent/issue-<number>` (e.g., `agent/issue-24`)
-- **No direct push to main** — always create a PR
+エージェントとして実行する場合は `agent/prompts/` 配下のプロンプトに従うこと。
+タスク実装時は `agent/prompts/implement.md` を参照。

--- a/agent/prompts/implement.md
+++ b/agent/prompts/implement.md
@@ -26,32 +26,6 @@ Implement exactly **one task** from a GitHub issue.
 - **Minimal changes** — don't refactor unrelated code
 - **No secrets** — never commit tokens, keys, or credentials
 
-## Architecture Reference
-
-```
-src/
-  main.rs          — terminal setup, event loop, draw(), keybindings
-  app.rs           — App struct (all state), View enum, InputMode enum
-  git/
-    mod.rs         — re-exports
-    branch.rs      — BranchInfo, list/create/switch/delete
-    diff.rs        — FileDiff, DiffChunk, diff_workdir(), diff_commit()
-    worktree.rs    — WorktreeInfo, list/add worktrees
-  ui/
-    mod.rs         — re-exports
-    branch.rs      — render_branches(frame, area, data, sel, focused)
-    diff.rs        — render_diff(frame, area, data, sel, scroll, focused)
-    worktree.rs    — render_worktrees(frame, area, data, sel, focused)
-```
-
-## Key Patterns
-
-- `anyhow::Result` + `with_context()` for all fallible operations
-- `Repository::discover(path)` to open repos (never hardcode paths)
-- `tempfile::TempDir` + `Repository::init()` for test isolation
-- UI renderers: `render_<view>(frame, area, &data, selection, focused) `
-- New views: add variant to `View` enum, add `<view>_sel` to App, add hotkey in main.rs
-
 ## Commit
 
 When done, stage and commit your changes with a conventional commit message.


### PR DESCRIPTION
## Summary

Implements issue #49: CLAUDE.md とプロンプトの冗長性

implement.md がCLAUDE.mdの内容を大部分繰り返しています（Architecture Reference, Key Patterns等）。

Claude.mdはシンプルにして、タスクを遂行する場合はimplement mdに従うというrefを書きましょう。
implementをしない時もあるので

Closes #49

---
Generated by agent/loop.sh