### PR TITLE
feat: GUI frontend: Diff view with syntax-highlighted file diffs

### DIFF
--- a/src-frontend/src/main.js
+++ b/src-frontend/src/main.js
@@ -282,6 +282,7 @@ function setupTabs() {
 // ── Diff表示 ─────────────────────────────────────────────────────
 
 let currentDiffs = [];
+let diffFocusPanel = "file-list"; // "file-list" or "content"
 
 async function loadDiff() {
   const container = document.getElementById("diff-file-list");
@@ -404,8 +405,19 @@ function renderDiffContent(diff) {
   }
 }
 
+function switchDiffFocus(panel) {
+  diffFocusPanel = panel || (diffFocusPanel === "file-list" ? "content" : "file-list");
+  const fileListPanel = document.querySelector(".diff-file-list");
+  const contentPanel = document.querySelector(".diff-view");
+  if (fileListPanel) fileListPanel.classList.toggle("focused", diffFocusPanel === "file-list");
+  if (contentPanel) contentPanel.classList.toggle("focused", diffFocusPanel === "content");
+}
+
 function setupDiff() {
   document.getElementById("diff-load-btn").addEventListener("click", loadDiff);
+  // クリックでパネルフォーカスを切り替え
+  document.querySelector(".diff-file-list").addEventListener("click", () => switchDiffFocus("file-list"));
+  document.querySelector(".diff-view").addEventListener("click", () => switchDiffFocus("content"));
 }
 
 // ── PR一覧 ──────────────────────────────────────────────────────
@@ -586,7 +598,10 @@ function setupKeyboardShortcuts() {
     switch (e.key) {
       case "Tab":
         e.preventDefault();
-        {
+        if (getActiveTab() === "diff") {
+          // Diffタブではパネル間のフォーカス切り替え
+          switchDiffFocus();
+        } else {
           const current = getActiveTab();
           const idx = TAB_ORDER.indexOf(current);
           const next = TAB_ORDER[(idx + 1) % TAB_ORDER.length];
@@ -608,12 +623,20 @@ function setupKeyboardShortcuts() {
       case "j":
       case "ArrowDown":
         e.preventDefault();
-        navigateList("down");
+        if (getActiveTab() === "diff" && diffFocusPanel === "content") {
+          document.getElementById("diff-content").scrollBy(0, 40);
+        } else {
+          navigateList("down");
+        }
         break;
       case "k":
       case "ArrowUp":
         e.preventDefault();
-        navigateList("up");
+        if (getActiveTab() === "diff" && diffFocusPanel === "content") {
+          document.getElementById("diff-content").scrollBy(0, -40);
+        } else {
+          navigateList("up");
+        }
         break;
       case "r":
         e.preventDefault();

--- a/src-frontend/src/style.css
+++ b/src-frontend/src/style.css
@@ -430,6 +430,11 @@ body {
   min-height: 500px;
 }
 
+.diff-file-list.focused,
+.diff-view.focused {
+  border-color: #4ec9b0;
+}
+
 .diff-file-list .list-container {
   max-height: none;
   flex: 1;


### PR DESCRIPTION
## Summary

Implements issue #53: GUI frontend: Diff view with syntax-highlighted file diffs

## Overview
Implement the **Diff view** in the GUI frontend with a two-pane layout: file list on the left, syntax-highlighted diff on the right.

## Tasks
- Build the Diff view component that calls `invoke('diff_workdir')` to fetch changed files and their diffs
- Implement a file list panel showing changed files with their status (modified, added, deleted)
- Implement a diff display panel showing chunk-level diffs with color coding (green for additions, red for deletions)
- Selecting a file in the file list shows its diff in the display panel
- Add keyboard shortcuts: `j`/`k` or arrow keys to navigate file list, `Tab` to switch focus between panels
- Style diff output to look polished with monospace font and clear visual distinction between added/removed lines

## Acceptance Criteria
- Diff view shows a list of changed files from the working directory
- Clicking or navigating to a file shows its diff with color-coded additions (green) and deletions (red)
- Two-pane layout works: file list on one side, diff content on the other
- Keyboard navigation works within file list and between panels
- Chunk headers (@@) are visually distinct

Parent: #37

Closes #53

---
Generated by agent/loop.sh