### PR TITLE
feat: Add requirement verification step after implementation

### DIFF
--- a/agent/lib/00_config.sh
+++ b/agent/lib/00_config.sh
@@ -12,6 +12,7 @@ CI_MAX_ATTEMPTS="${CI_MAX_ATTEMPTS:-5}"         # max CI check+fix cycles
 CI_INITIAL_WAIT="${CI_INITIAL_WAIT:-60}"        # seconds to wait before first CI check
 CI_POLL_INTERVAL="${CI_POLL_INTERVAL:-30}"      # seconds between CI status polls
 CI_POLL_TIMEOUT="${CI_POLL_TIMEOUT:-600}"       # max seconds for one polling window (default 10min)
+VERIFY_MAX_TURNS="${VERIFY_MAX_TURNS:-10}"
 PROPOSE_MAX_TURNS="${PROPOSE_MAX_TURNS:-10}"
 LOG_MAX_BYTES="${LOG_MAX_BYTES:-524288}"       # 512KB per file
 LOG_MAX_FILES="${LOG_MAX_FILES:-3}"             # keep progress.txt + 3 archives

--- a/agent/loop.sh
+++ b/agent/loop.sh
@@ -87,7 +87,7 @@ rm -f "$RATE_LIMIT_FLAG"
 ensure_labels
 
 # ── Step execution order ─────────────────────────────────────────────────────
-STEP_ORDER=(step_setup step_triage step_select step_implement step_verify step_push step_ci step_complete)
+STEP_ORDER=(step_setup step_triage step_select step_implement step_verify step_reqverify step_push step_ci step_complete)
 
 # ── Main Loop ────────────────────────────────────────────────────────────────
 iteration=0

--- a/agent/prompts/verify.md
+++ b/agent/prompts/verify.md
@@ -1,0 +1,43 @@
+# Requirement Verification Agent
+
+You are the requirement verification agent for the **reown** project.
+
+## Your Job
+
+Verify that the implementation (git diff) satisfies the issue's requirements.
+
+## Input
+
+You will receive:
+1. The original issue title and body (requirements / acceptance criteria)
+2. The full git diff of all changes made (`git diff main...HEAD`)
+
+## Rules
+
+- Compare each acceptance criterion in the issue against the diff
+- Check that the implementation addresses the core problem described
+- Do NOT run any commands or modify any files — this is a read-only review
+- Be pragmatic: minor style differences or extra improvements are acceptable
+- Focus on whether the functional requirements are met
+
+## Output Format
+
+Output ONLY a JSON object inside a ```json fence:
+
+### On pass:
+```json
+{
+  "verdict": "pass",
+  "reasoning": "Brief explanation of why all requirements are met"
+}
+```
+
+### On fail:
+```json
+{
+  "verdict": "fail",
+  "reasoning": "What specific requirement(s) are not met and what needs to change"
+}
+```
+
+No other text before or after the fence.

--- a/agent/steps/05a_reqverify.sh
+++ b/agent/steps/05a_reqverify.sh
@@ -1,0 +1,126 @@
+# agent/steps/05a_reqverify.sh — step_reqverify: verify implementation meets issue requirements
+# Return: 0=ok, 1=skip iteration, 2=break loop
+
+step_reqverify() {
+  cd "$REPO_ROOT"
+
+  local VERIFY_PROMPT DIFF_OUTPUT VERIFY_INPUT VERIFY_STDERR VERIFY_OUTPUT VERIFY_JSON VERDICT REASONING
+
+  VERIFY_PROMPT=$(cat "$SCRIPT_DIR/prompts/verify.md")
+  DIFF_OUTPUT=$(git diff main...HEAD 2>/dev/null || git diff main 2>/dev/null || echo "(no diff available)")
+
+  VERIFY_INPUT="$VERIFY_PROMPT
+
+## Issue
+
+- **Title**: $TASK_TITLE
+- **Body**: $TASK_DESC
+
+## Git Diff (main...HEAD)
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`"
+
+  log "Running requirement verification for #$TASK_ISSUE..."
+  VERIFY_STDERR="/tmp/claude/agent-reqverify-stderr.log"
+  VERIFY_OUTPUT=$(claude -p "$VERIFY_INPUT" \
+    --max-turns "$VERIFY_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    2>"$VERIFY_STDERR") || true
+
+  # Rate limit check
+  if check_rate_limit "$VERIFY_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  # Parse verdict from output
+  VERIFY_JSON=$(echo "$VERIFY_OUTPUT" | sed -n '/^```json$/,/^```$/{ /^```/d; p; }')
+  VERDICT=$(echo "$VERIFY_JSON" | jq -r '.verdict' 2>/dev/null || echo "")
+  REASONING=$(echo "$VERIFY_JSON" | jq -r '.reasoning' 2>/dev/null || echo "")
+
+  if [[ "$VERDICT" == "pass" ]]; then
+    log "Requirement verification passed for #$TASK_ISSUE: $REASONING"
+    return 0
+  fi
+
+  if [[ "$VERDICT" != "fail" ]]; then
+    log "WARN: Could not parse verify agent output for #$TASK_ISSUE. Treating as pass."
+    return 0
+  fi
+
+  # ── First failure: attempt fix + re-verify ─────────────────────────────────
+  log "Requirement verification failed for #$TASK_ISSUE: $REASONING"
+  log "Attempting fix based on verification feedback..."
+
+  local FIX_STDERR="/tmp/claude/agent-reqverify-fix-stderr.log"
+  claude -p "The requirement verification agent found that the implementation does not fully satisfy the issue requirements.
+
+## Issue
+- **Title**: $TASK_TITLE
+- **Body**: $TASK_DESC
+
+## Verification Feedback
+$REASONING
+
+Please fix the implementation to address the gap. Then run cargo test and cargo clippy --all-targets -- -D warnings to ensure everything still passes. Commit your changes." \
+    --max-turns "$FIX_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+    2>"$FIX_STDERR" || true
+
+  if check_rate_limit "$FIX_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  # ── Re-verify after fix ────────────────────────────────────────────────────
+  DIFF_OUTPUT=$(git diff main...HEAD 2>/dev/null || git diff main 2>/dev/null || echo "(no diff available)")
+  VERIFY_INPUT="$VERIFY_PROMPT
+
+## Issue
+
+- **Title**: $TASK_TITLE
+- **Body**: $TASK_DESC
+
+## Git Diff (main...HEAD)
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`"
+
+  log "Re-running requirement verification for #$TASK_ISSUE after fix..."
+  VERIFY_STDERR="/tmp/claude/agent-reqverify-retry-stderr.log"
+  VERIFY_OUTPUT=$(claude -p "$VERIFY_INPUT" \
+    --max-turns "$VERIFY_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    2>"$VERIFY_STDERR") || true
+
+  if check_rate_limit "$VERIFY_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  VERIFY_JSON=$(echo "$VERIFY_OUTPUT" | sed -n '/^```json$/,/^```$/{ /^```/d; p; }')
+  VERDICT=$(echo "$VERIFY_JSON" | jq -r '.verdict' 2>/dev/null || echo "")
+  REASONING=$(echo "$VERIFY_JSON" | jq -r '.reasoning' 2>/dev/null || echo "")
+
+  if [[ "$VERDICT" == "pass" ]]; then
+    log "Requirement verification passed on retry for #$TASK_ISSUE: $REASONING"
+    return 0
+  fi
+
+  # ── Final failure: mark as needs-split ─────────────────────────────────────
+  log "ERROR: Requirement verification still failing for #$TASK_ISSUE after fix attempt. Marking as needs-split."
+  mark_needs_split "$TASK_ISSUE"
+  cleanup_branch "$BRANCH_NAME"
+  sleep "$SLEEP_SECONDS"
+  return 1
+}


### PR DESCRIPTION
## Summary

Implements issue #57: Add requirement verification step after implementation

## Problem

After the agent implements a task, the only checks are `cargo test` and `cargo clippy`. There is no verification that the implementation actually satisfies the issue's requirements.

## Solution

Add a **requirement verification step** in `agent/loop.sh` between the implementation step and the pre-push verification step. This step should:

1. Invoke a new "verify" agent (via `claude -p`) that receives:
   - The original issue title and body
   - The git diff of all changes made (`git diff main...HEAD`)
2. The verify agent checks whether the diff satisfies the issue's acceptance criteria / requirements
3. Output a structured verdict: `pass` or `fail` with reasoning
4. On `fail`: invoke the fix agent to address the gap, then re-verify (1 retry)
5. On final fail: mark issue as `needs-split` and skip

## Files to change

- `agent/loop.sh` — add verify step after clippy, before pre-push verification
- `agent/prompts/verify.md` — new prompt file for the verify agent

## Acceptance criteria

- [ ] New verify step runs after cargo test + clippy pass
- [ ] Verify agent receives issue body and full diff
- [ ] On pass: proceed to push
- [ ] On fail: attempt fix + re-verify once, then mark `needs-split`
- [ ] Verify step is logged in progress.txt

Parent: #45

Closes #57

---
Generated by agent/loop.sh