### PR TITLE
feat: Add code review quality check before PR creation

### DIFF
--- a/agent/lib/00_config.sh
+++ b/agent/lib/00_config.sh
@@ -13,6 +13,7 @@ CI_INITIAL_WAIT="${CI_INITIAL_WAIT:-60}"        # seconds to wait before first C
 CI_POLL_INTERVAL="${CI_POLL_INTERVAL:-30}"      # seconds between CI status polls
 CI_POLL_TIMEOUT="${CI_POLL_TIMEOUT:-600}"       # max seconds for one polling window (default 10min)
 VERIFY_MAX_TURNS="${VERIFY_MAX_TURNS:-10}"
+REVIEW_MAX_TURNS="${REVIEW_MAX_TURNS:-10}"
 PROPOSE_MAX_TURNS="${PROPOSE_MAX_TURNS:-10}"
 LOG_MAX_BYTES="${LOG_MAX_BYTES:-524288}"       # 512KB per file
 LOG_MAX_FILES="${LOG_MAX_FILES:-3}"             # keep progress.txt + 3 archives

--- a/agent/loop.sh
+++ b/agent/loop.sh
@@ -87,7 +87,7 @@ rm -f "$RATE_LIMIT_FLAG"
 ensure_labels
 
 # ── Step execution order ─────────────────────────────────────────────────────
-STEP_ORDER=(step_setup step_triage step_select step_implement step_verify step_reqverify step_push step_ci step_complete)
+STEP_ORDER=(step_setup step_triage step_select step_implement step_verify step_reqverify step_review step_push step_ci step_complete)
 
 # ── Main Loop ────────────────────────────────────────────────────────────────
 iteration=0

--- a/agent/prompts/review.md
+++ b/agent/prompts/review.md
@@ -1,0 +1,56 @@
+# Code Review Agent
+
+You are the code review agent for the **reown** project.
+
+## Your Job
+
+Review the implementation diff for code quality issues — like a human code reviewer would.
+
+## Input
+
+You will receive:
+1. The full git diff of all changes made (`git diff main...HEAD`)
+2. The project's coding patterns from CLAUDE.md
+
+## What to Check
+
+- **Pattern compliance**: Error handling uses `anyhow::Result` with `with_context()`, tests use `tempfile::TempDir` pattern, Tauri commands follow the wrapper pattern
+- **Dead code**: No unused imports, functions, variables, or debug artifacts (println!, dbg!, TODO/FIXME left behind)
+- **Minimal and focused changes**: No unrelated modifications, refactors, or additions beyond the task scope
+- **Logic correctness**: No obvious logic errors, off-by-one errors, or anti-patterns
+- **Naming**: Variables and functions have clear, descriptive names consistent with the existing codebase
+- **Error handling**: No unwrap() on fallible operations in production code (tests are fine), errors are propagated properly
+- **Security**: No hardcoded secrets, no command injection risks, no unsafe blocks without justification
+
+## Rules
+
+- Do NOT run any commands or modify any files — this is a read-only review
+- Be pragmatic: minor style differences are acceptable
+- Focus on issues that could cause bugs, maintenance problems, or security risks
+- Ignore changes to test files for dead code checks (test helpers are fine)
+
+## Output Format
+
+Output ONLY a JSON object inside a ```json fence:
+
+### On pass:
+```json
+{
+  "verdict": "pass",
+  "reasoning": "Brief summary of the review"
+}
+```
+
+### On fail:
+```json
+{
+  "verdict": "fail",
+  "issues": [
+    "Specific issue 1 with file path and line reference",
+    "Specific issue 2 with file path and line reference"
+  ],
+  "reasoning": "Summary of what needs to be fixed"
+}
+```
+
+No other text before or after the fence.

--- a/agent/steps/05b_review.sh
+++ b/agent/steps/05b_review.sh
@@ -1,0 +1,127 @@
+# agent/steps/05b_review.sh — step_review: code review quality check before push
+# Return: 0=ok, 1=skip iteration, 2=break loop
+
+step_review() {
+  cd "$REPO_ROOT"
+
+  local REVIEW_PROMPT CLAUDE_MD DIFF_OUTPUT REVIEW_INPUT REVIEW_STDERR REVIEW_OUTPUT REVIEW_JSON VERDICT REASONING
+
+  REVIEW_PROMPT=$(cat "$SCRIPT_DIR/prompts/review.md")
+  CLAUDE_MD=$(cat "$REPO_ROOT/CLAUDE.md" 2>/dev/null || echo "(CLAUDE.md not found)")
+  DIFF_OUTPUT=$(git diff main...HEAD 2>/dev/null || git diff main 2>/dev/null || echo "(no diff available)")
+
+  REVIEW_INPUT="$REVIEW_PROMPT
+
+## CLAUDE.md (Project Patterns)
+
+$CLAUDE_MD
+
+## Git Diff (main...HEAD)
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`"
+
+  log "Running code review for #$TASK_ISSUE..."
+  REVIEW_STDERR="/tmp/claude/agent-review-stderr.log"
+  REVIEW_OUTPUT=$(claude -p "$REVIEW_INPUT" \
+    --max-turns "$REVIEW_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    2>"$REVIEW_STDERR") || true
+
+  # Rate limit check
+  if check_rate_limit "$REVIEW_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  # Parse verdict from output
+  REVIEW_JSON=$(echo "$REVIEW_OUTPUT" | sed -n '/^```json$/,/^```$/{ /^```/d; p; }')
+  VERDICT=$(echo "$REVIEW_JSON" | jq -r '.verdict' 2>/dev/null || echo "")
+  REASONING=$(echo "$REVIEW_JSON" | jq -r '.reasoning' 2>/dev/null || echo "")
+
+  if [[ "$VERDICT" == "pass" ]]; then
+    log "Code review passed for #$TASK_ISSUE: $REASONING"
+    return 0
+  fi
+
+  if [[ "$VERDICT" != "fail" ]]; then
+    log "WARN: Could not parse review agent output for #$TASK_ISSUE. Treating as pass."
+    return 0
+  fi
+
+  # ── First failure: attempt fix + re-review ─────────────────────────────────
+  local ISSUES
+  ISSUES=$(echo "$REVIEW_JSON" | jq -r '.issues // [] | join("\n")' 2>/dev/null || echo "$REASONING")
+
+  log "Code review failed for #$TASK_ISSUE: $REASONING"
+  log "Attempting fix based on review feedback..."
+
+  local FIX_STDERR="/tmp/claude/agent-review-fix-stderr.log"
+  claude -p "The code review agent found quality issues in the implementation.
+
+## Review Issues
+$ISSUES
+
+## Review Summary
+$REASONING
+
+Please fix the issues identified by the review. Then run cargo test and cargo clippy --all-targets -- -D warnings to ensure everything still passes. Commit your changes." \
+    --max-turns "$FIX_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+    2>"$FIX_STDERR" || true
+
+  if check_rate_limit "$FIX_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  # ── Re-review after fix ────────────────────────────────────────────────────
+  DIFF_OUTPUT=$(git diff main...HEAD 2>/dev/null || git diff main 2>/dev/null || echo "(no diff available)")
+  REVIEW_INPUT="$REVIEW_PROMPT
+
+## CLAUDE.md (Project Patterns)
+
+$CLAUDE_MD
+
+## Git Diff (main...HEAD)
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`"
+
+  log "Re-running code review for #$TASK_ISSUE after fix..."
+  REVIEW_STDERR="/tmp/claude/agent-review-retry-stderr.log"
+  REVIEW_OUTPUT=$(claude -p "$REVIEW_INPUT" \
+    --max-turns "$REVIEW_MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET_USD" \
+    2>"$REVIEW_STDERR") || true
+
+  if check_rate_limit "$REVIEW_STDERR"; then
+    flag_rate_limit
+    gh issue edit "$TASK_ISSUE" --remove-label "doing" 2>/dev/null || true
+    cleanup_branch "$BRANCH_NAME"
+    return 2
+  fi
+
+  REVIEW_JSON=$(echo "$REVIEW_OUTPUT" | sed -n '/^```json$/,/^```$/{ /^```/d; p; }')
+  VERDICT=$(echo "$REVIEW_JSON" | jq -r '.verdict' 2>/dev/null || echo "")
+  REASONING=$(echo "$REVIEW_JSON" | jq -r '.reasoning' 2>/dev/null || echo "")
+
+  if [[ "$VERDICT" == "pass" ]]; then
+    log "Code review passed on retry for #$TASK_ISSUE: $REASONING"
+    return 0
+  fi
+
+  # ── Final failure: mark as needs-split ─────────────────────────────────────
+  log "ERROR: Code review still failing for #$TASK_ISSUE after fix attempt. Marking as needs-split."
+  mark_needs_split "$TASK_ISSUE"
+  cleanup_branch "$BRANCH_NAME"
+  sleep "$SLEEP_SECONDS"
+  return 1
+}


### PR DESCRIPTION
## Summary

Implements issue #58: Add code review quality check before PR creation

## Problem

There is no code review-like quality check. The agent may produce code that compiles and passes tests but has quality issues (unused code, poor naming, missing error handling, overly complex logic, etc.).

## Solution

Add a **code review step** in `agent/loop.sh` after requirement verification and before push. This step should:

1. Invoke a new "review" agent (via `claude -p`) that receives:
   - The full diff (`git diff main...HEAD`)
   - The project's CLAUDE.md patterns
2. The review agent checks for:
   - Code follows existing patterns (error handling with `anyhow`, test patterns, etc.)
   - No dead code or debug artifacts left behind
   - Changes are minimal and focused (no unrelated modifications)
   - No obvious logic errors or anti-patterns
3. Output a structured verdict: `pass` or `fail` with specific issues
4. On `fail`: invoke fix agent with the review feedback, then re-review (1 retry)
5. On final fail: mark issue as `needs-split` and skip

## Files to change

- `agent/loop.sh` — add review step after verify step, before pre-push verification
- `agent/prompts/review.md` — new prompt file for the review agent

## Acceptance criteria

- [ ] New review step runs after requirement verification passes
- [ ] Review agent receives full diff and project patterns
- [ ] On pass: proceed to push
- [ ] On fail: attempt fix + re-review once, then mark `needs-split`
- [ ] Review step is logged in progress.txt

Parent: #45

Closes #58

---
Generated by agent/loop.sh