### PR TITLE
feat: [frontend] ローカルの format / lint 設定の導入

### DIFF
--- a/src-frontend/.prettierrc
+++ b/src-frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/src-frontend/eslint.config.js
+++ b/src-frontend/eslint.config.js
@@ -2,6 +2,7 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
   { ignores: ["out"] },
@@ -19,5 +20,6 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
     },
-  }
+  },
+  eslintConfigPrettier
 );

--- a/src-frontend/package-lock.json
+++ b/src-frontend/package-lock.json
@@ -18,8 +18,10 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "eslint": "^9.39.3",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.26",
+        "prettier": "^3.8.1",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.56.0",
         "vite": "^6.0.0"
@@ -56,7 +58,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1428,7 +1429,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1488,7 +1488,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1766,7 +1765,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1875,7 +1873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2097,7 +2094,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2150,6 +2146,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -2806,6 +2818,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2821,7 +2849,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3027,7 +3054,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3107,7 +3133,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src-frontend/package.json
+++ b/src-frontend/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css,html}' '*.{js,ts,json}'",
+    "format:check": "prettier --check 'src/**/*.{ts,tsx,css,html}' '*.{js,ts,json}'",
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
@@ -21,8 +23,10 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "eslint": "^9.39.3",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",
+    "prettier": "^3.8.1",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.56.0",
     "vite": "^6.0.0"

--- a/src-frontend/src/components/BranchTab.tsx
+++ b/src-frontend/src/components/BranchTab.tsx
@@ -106,9 +106,7 @@ export function BranchTab({ showConfirm }: Props) {
                   {b.is_head ? `* ${b.name}` : b.name}
                 </div>
                 {b.upstream && (
-                  <div className="branch-upstream">
-                    upstream: {b.upstream}
-                  </div>
+                  <div className="branch-upstream">upstream: {b.upstream}</div>
                 )}
               </div>
               {!b.is_head && (

--- a/src-frontend/src/components/DiffTab.tsx
+++ b/src-frontend/src/components/DiffTab.tsx
@@ -94,7 +94,7 @@ export function DiffTab() {
         <section className="diff-view panel">
           <h2>
             {selectedDiff
-              ? selectedDiff.new_path ?? selectedDiff.old_path ?? "Diff"
+              ? (selectedDiff.new_path ?? selectedDiff.old_path ?? "Diff")
               : "Diff"}
           </h2>
           <div className="diff-content">

--- a/src-frontend/src/components/WorktreeTab.tsx
+++ b/src-frontend/src/components/WorktreeTab.tsx
@@ -74,9 +74,7 @@ export function WorktreeTab() {
               <span className={`wt-name${wt.is_main ? " main" : ""}`}>
                 {wt.name}
               </span>
-              {wt.is_locked && (
-                <span className="wt-badge locked">locked</span>
-              )}
+              {wt.is_locked && <span className="wt-badge locked">locked</span>}
               {!wt.branch && (
                 <span className="wt-badge detached">detached</span>
               )}

--- a/src-frontend/src/style.css
+++ b/src-frontend/src/style.css
@@ -5,8 +5,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, sans-serif;
   background-color: #1a1a2e;
   color: #e0e0e0;
   min-height: 100vh;
@@ -53,7 +54,9 @@ body {
   color: #a0a0b0;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .tab-btn:hover {


### PR DESCRIPTION
## Summary

Implements issue #76: [frontend] ローカルの format / lint 設定の導入

## 概要

フロントエンドのローカル開発環境に ESLint + Prettier を導入し、コードスタイルの統一と品質チェックを自動化する。

## やること

- ESLint の導入・設定（React + TypeScript 向け）
- Prettier の導入・設定
- `package.json` に `lint`, `format`, `format:check` スクリプトを追加
- `.eslintrc` / `eslint.config.js` と `.prettierrc` の設定ファイル作成
- 既存コードの lint エラー・フォーマット修正

## 備考

- このissueはフロントエンドのタスクです
- Vite + React 導入後に対応する

Closes #76

---
Generated by agent/loop.sh