### PR TITLE
refactor: [backend] repo_path の重複ボイラープレートを解消する

### DIFF
--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
-use git2::{BranchType, Repository};
+use git2::BranchType;
+
+use super::open_repo;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct BranchInfo {
@@ -10,8 +12,7 @@ pub struct BranchInfo {
 
 /// List all local branches for the repository at `repo_path`.
 pub fn list_branches(repo_path: &str) -> Result<Vec<BranchInfo>> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let mut branches = Vec::new();
     for branch_result in repo.branches(Some(BranchType::Local))? {
@@ -34,8 +35,7 @@ pub fn list_branches(repo_path: &str) -> Result<Vec<BranchInfo>> {
 
 /// Create a new local branch from HEAD.
 pub fn create_branch(repo_path: &str, name: &str) -> Result<()> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let head_commit = repo
         .head()?
@@ -50,8 +50,7 @@ pub fn create_branch(repo_path: &str, name: &str) -> Result<()> {
 
 /// Switch (checkout) to an existing local branch.
 pub fn switch_branch(repo_path: &str, name: &str) -> Result<()> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let branch = repo
         .find_branch(name, BranchType::Local)
@@ -73,8 +72,7 @@ pub fn switch_branch(repo_path: &str, name: &str) -> Result<()> {
 
 /// Delete a local branch. Refuses to delete the currently checked-out branch.
 pub fn delete_branch(repo_path: &str, name: &str) -> Result<()> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let mut branch = repo
         .find_branch(name, BranchType::Local)

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
-use git2::{Delta, DiffDelta, DiffHunk, DiffLine, Repository};
+use git2::{Delta, DiffDelta, DiffHunk, DiffLine};
+
+use super::open_repo;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub enum LineOrigin {
@@ -65,8 +67,7 @@ impl From<Delta> for FileStatus {
 
 /// Return the diff of the working directory against HEAD.
 pub fn diff_workdir(repo_path: &str) -> Result<Vec<FileDiff>> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let head_tree = match repo.head() {
         Ok(head) => Some(head.peel_to_tree()?),
@@ -83,8 +84,7 @@ pub fn diff_workdir(repo_path: &str) -> Result<Vec<FileDiff>> {
 /// Return the diff introduced by `commit_sha` relative to its first parent.
 #[allow(dead_code)] // used in Phase 2 for PR diff display
 pub fn diff_commit(repo_path: &str, commit_sha: &str) -> Result<Vec<FileDiff>> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let oid = repo
         .revparse_single(commit_sha)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,3 +1,15 @@
 pub mod branch;
 pub mod diff;
 pub mod worktree;
+
+use anyhow::{Context, Result};
+use git2::Repository;
+
+/// Open the repository at or above `repo_path`.
+///
+/// This is the single entry point for `Repository::discover`, eliminating
+/// the duplicated boilerplate across branch/diff/worktree modules.
+pub fn open_repo(repo_path: &str) -> Result<Repository> {
+    Repository::discover(repo_path)
+        .with_context(|| format!("Failed to open repository at {repo_path}"))
+}

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use git2::{Repository, Worktree};
 use std::path::PathBuf;
 
+use super::open_repo;
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct WorktreeInfo {
     pub name: String,
@@ -14,8 +16,7 @@ pub struct WorktreeInfo {
 
 /// List all worktrees for the given repository path.
 pub fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let mut result = Vec::new();
 
@@ -58,8 +59,7 @@ pub fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>> {
 /// Add a new worktree at `path` checked out to `branch` (creates branch if
 /// it doesn't exist).
 pub fn add_worktree(repo_path: &str, worktree_path: &str, branch: &str) -> Result<()> {
-    let repo = Repository::discover(repo_path)
-        .with_context(|| format!("Failed to open repository at {repo_path}"))?;
+    let repo = open_repo(repo_path)?;
 
     let path = std::path::Path::new(worktree_path);
 


### PR DESCRIPTION
## Summary

Implements issue #83: [backend] repo_path の重複ボイラープレートを解消する

## 概要

全関数で `Repository::discover(repo_path).with_context(...)` を繰り返している。ヘルパー関数やRepositoryを保持する構造体を導入して重複を解消する。

## 現状

`branch.rs`, `diff.rs`, `worktree.rs` の各関数すべてに以下のパターンが繰り返されている:

```rust
let repo = Repository::discover(repo_path)
    .with_context(|| format!("Failed to open repository at {repo_path}"))?;
```

## やること

- `open_repo(repo_path: &str) -> Result<Repository>` のようなヘルパー関数を導入
- または Repository を保持する構造体でメソッドチェーン化を検討
- 全モジュールの呼び出しを統一

## 備考

- このissueはバックエンドのタスクです

Closes #83

---
Generated by agent/loop.sh