### PR TITLE
feat: [backend] GitHub API を async 化する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -2830,9 +2829,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ git2 = "0.20.4"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,12 +54,13 @@ fn diff_commit(
 // ── GitHub commands ─────────────────────────────────────────────────────────
 
 #[tauri::command]
-fn list_pull_requests(
+async fn list_pull_requests(
     owner: String,
     repo: String,
     token: String,
 ) -> Result<Vec<reown::github::PrInfo>, String> {
     reown::github::pull_request::list_pull_requests(&owner, &repo, &token)
+        .await
         .map_err(|e| format!("{e:#}"))
 }
 


### PR DESCRIPTION
## Summary

Implements issue #84: [backend] GitHub API を async 化する

## 概要

現在 `reqwest::blocking` を使って同期的にGitHub APIを呼び出している。将来的にページネーションや複数API呼び出しが増えた際にUIブロッキングの原因になるため、async化する。

## 現状

- `pull_request.rs` で `reqwest::blocking::Client` を使用
- Tauriコマンドはスレッドプールで実行されるため今は動作するが、スケールしない

## やること

- `reqwest::blocking` → `reqwest`（async）への移行
- Tauriコマンドを `async fn` に変更
- Cargo.toml の依存関係から `blocking` feature を削除

## 備考

- このissueはバックエンドのタスクです

Closes #84

---
Generated by agent/loop.sh