### PR TITLE
refactor: [backend] テストユーティリティの共通化

### DIFF
--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -92,31 +92,7 @@ pub fn delete_branch(repo_path: &str, name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use git2::Repository;
-    use tempfile::TempDir;
-
-    fn init_test_repo() -> (TempDir, Repository) {
-        let dir = TempDir::new().unwrap();
-        let repo = Repository::init(dir.path()).unwrap();
-
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test").unwrap();
-        config.set_str("user.email", "test@test.com").unwrap();
-        drop(config);
-
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let tree_id = {
-            let mut index = repo.index().unwrap();
-            index.write_tree().unwrap()
-        };
-        {
-            let tree = repo.find_tree(tree_id).unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
-                .unwrap();
-        }
-
-        (dir, repo)
-    }
+    use crate::git::test_utils::init_test_repo;
 
     #[test]
     fn test_list_branches_single_branch() {

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -173,34 +173,9 @@ fn collect_diff(diff: &git2::Diff<'_>) -> Result<Vec<FileDiff>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use git2::{Repository, Signature};
+    use crate::git::test_utils::init_repo_with_commit;
+    use git2::Signature;
     use std::fs;
-    use tempfile::TempDir;
-
-    fn init_repo_with_commit() -> (TempDir, Repository) {
-        let dir = TempDir::new().unwrap();
-        let repo = Repository::init(dir.path()).unwrap();
-
-        let mut cfg = repo.config().unwrap();
-        cfg.set_str("user.name", "Test").unwrap();
-        cfg.set_str("user.email", "test@test.com").unwrap();
-        drop(cfg);
-
-        // Write and commit a file.
-        fs::write(dir.path().join("hello.txt"), "hello\n").unwrap();
-        let sig = Signature::now("Test", "test@test.com").unwrap();
-        let mut index = repo.index().unwrap();
-        index.add_path(std::path::Path::new("hello.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        {
-            let tree = repo.find_tree(tree_id).unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
-                .unwrap();
-        }
-
-        (dir, repo)
-    }
 
     #[test]
     fn test_diff_workdir_clean() {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,5 +1,7 @@
 pub mod branch;
 pub mod diff;
+#[cfg(test)]
+pub mod test_utils;
 pub mod worktree;
 
 use anyhow::{Context, Result};

--- a/src/git/test_utils.rs
+++ b/src/git/test_utils.rs
@@ -1,0 +1,58 @@
+use git2::Repository;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Create a test repository with an initial empty commit.
+///
+/// Returns (TempDir, Repository). The TempDir must be kept alive for the
+/// duration of the test to prevent the directory from being deleted.
+pub fn init_test_repo() -> (TempDir, Repository) {
+    let dir = TempDir::new().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "Test").unwrap();
+    config.set_str("user.email", "test@test.com").unwrap();
+    drop(config);
+
+    let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+    let tree_id = {
+        let mut index = repo.index().unwrap();
+        index.write_tree().unwrap()
+    };
+    {
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+    }
+
+    (dir, repo)
+}
+
+/// Create a test repository with an initial commit that includes `hello.txt`.
+///
+/// This is useful for tests that need a tracked file in the working tree
+/// (e.g. diff tests).
+pub fn init_repo_with_commit() -> (TempDir, Repository) {
+    let dir = TempDir::new().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "Test").unwrap();
+    config.set_str("user.email", "test@test.com").unwrap();
+    drop(config);
+
+    std::fs::write(dir.path().join("hello.txt"), "hello\n").unwrap();
+    let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("hello.txt")).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    {
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+    }
+
+    (dir, repo)
+}

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -99,32 +99,7 @@ fn worktree_branch(wt_path: &PathBuf) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
-
-    fn init_test_repo() -> (TempDir, Repository) {
-        let dir = TempDir::new().unwrap();
-        let repo = Repository::init(dir.path()).unwrap();
-
-        // Configure git user for commits
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test").unwrap();
-        config.set_str("user.email", "test@test.com").unwrap();
-        drop(config);
-
-        // Create initial commit so HEAD exists
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let tree_id = {
-            let mut index = repo.index().unwrap();
-            index.write_tree().unwrap()
-        };
-        {
-            let tree = repo.find_tree(tree_id).unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
-                .unwrap();
-        }
-
-        (dir, repo)
-    }
+    use crate::git::test_utils::init_test_repo;
 
     #[test]
     fn test_list_worktrees_main_only() {


### PR DESCRIPTION
## Summary

Implements issue #88: [backend] テストユーティリティの共通化

## 概要

`branch.rs`、`diff.rs`、`worktree.rs` にそれぞれ似た `init_test_repo` / `init_repo_with_commit` 関数がコピペされている。テストヘルパーとして共通化する。

## 現状

3ファイルにほぼ同じ内容のテスト初期化関数がある:
- `branch.rs` → `init_test_repo()`
- `diff.rs` → `init_repo_with_commit()`
- `worktree.rs` → `init_test_repo()`

## やること

- `src/test_utils.rs`（または `src/git/test_utils.rs`）にテストヘルパーを集約
- `#[cfg(test)]` モジュールとして公開
- 各テストモジュールから共通ヘルパーを使うよう修正

## 備考

- このissueはバックエンドのタスクです

Closes #88

---
Generated by agent/loop.sh