### PR TITLE
docs: [docs] README にプロジェクト構成を整理・追記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,26 +20,34 @@ cargo clippy --all-targets -- -D warnings
 
 ```
 lib/                        — shared library (reown crate)
-  lib.rs                    — crate root, re-exports git, github
+  lib.rs                    — crate root, re-exports git, github, ui
   git/
-    mod.rs                  — re-exports branch, diff, worktree
+    mod.rs                  — open_repo() + re-exports branch, diff, worktree
     branch.rs               — BranchInfo, list/create/switch/delete branches
     diff.rs                 — FileDiff, DiffChunk, diff_workdir(), diff_commit()
     worktree.rs             — WorktreeInfo, list/add worktrees
+    test_utils.rs           — shared test utilities
   github/
     mod.rs                  — re-exports pull_request, types
     pull_request.rs         — PrInfo, list_pull_requests()
     types.rs                — GitHub API response types
+  ui/
+    mod.rs                  — re-exports pull_request
+    pull_request.rs         — PR display utilities
 
 app/                        — Tauri desktop app (entry point)
   src/main.rs               — Tauri commands (IPC bridge to reown lib)
+  src/error.rs              — AppError struct (structured error for frontend)
   tauri.conf.json           — Tauri config, bundler settings
   build.rs                  — Tauri build script
 
-frontend/                   — Web frontend (HTML/CSS/JS)
-  src/index.html            — App shell
-  src/style.css             — Styles
-  src/main.js               — Frontend logic, Tauri invoke calls
+frontend/                   — Web frontend (React + TypeScript)
+  src/main.tsx              — React entry point
+  src/App.tsx               — Main app component (tab UI)
+  src/types.ts              — TypeScript type definitions (mirrors Rust structs)
+  src/invoke.ts             — Tauri IPC wrapper
+  src/components/           — UI components (WorktreeTab, BranchTab, DiffTab, PrTab)
+  src/i18n/                 — i18n (ja/en)
 ```
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -18,6 +18,113 @@ AIエージェントが大量のPRを生成する時代に、コードベース�
 
 ---
 
+## プロジェクト構成
+
+### ディレクトリ構造
+
+```
+reown/
+├── Cargo.toml              # ワークスペースルート（lib + app）
+├── Cargo.lock
+├── README.md
+├── CLAUDE.md               # 開発ガイドライン
+├── mise.toml               # ツールバージョン管理（Node.js, Rust）
+│
+├── lib/                    # 共有ライブラリ（reown クレート）
+│   ├── lib.rs              #   クレートルート — git, github, ui を再エクスポート
+│   ├── git/
+│   │   ├── mod.rs          #   open_repo() + サブモジュール再エクスポート
+│   │   ├── branch.rs       #   BranchInfo, ブランチ操作（一覧/作成/切替/削除）
+│   │   ├── diff.rs         #   FileDiff, DiffChunk, diff_workdir(), diff_commit()
+│   │   ├── worktree.rs     #   WorktreeInfo, ワークツリー操作（一覧/追加）
+│   │   └── test_utils.rs   #   テスト用ユーティリティ
+│   ├── github/
+│   │   ├── mod.rs          #   サブモジュール再エクスポート
+│   │   ├── pull_request.rs #   PrInfo, list_pull_requests()
+│   │   └── types.rs        #   GitHub API レスポンス型
+│   └── ui/
+│       ├── mod.rs          #   サブモジュール再エクスポート
+│       └── pull_request.rs #   PR表示用ユーティリティ
+│
+├── app/                    # Tauri デスクトップアプリ（エントリポイント）
+│   ├── Cargo.toml          #   アプリ固有の依存関係（tauri, reown）
+│   ├── build.rs            #   Tauri ビルドスクリプト
+│   ├── tauri.conf.json     #   Tauri 設定（ウィンドウサイズ、バンドラー等）
+│   ├── src/
+│   │   ├── main.rs         #   #[tauri::command] ハンドラ + アプリ起動
+│   │   └── error.rs        #   AppError 構造体（フロントエンド向けエラー型）
+│   └── icons/
+│       └── icon.png        #   アプリアイコン
+│
+├── frontend/               # Web フロントエンド（React + TypeScript）
+│   ├── package.json        #   NPM 依存関係・スクリプト
+│   ├── vite.config.ts      #   Vite ビルド設定
+│   ├── tsconfig.json       #   TypeScript 設定
+│   ├── index.html          #   HTML エントリポイント
+│   └── src/
+│       ├── main.tsx        #   React エントリポイント
+│       ├── App.tsx         #   メインアプリ（タブ UI）
+│       ├── types.ts        #   TypeScript 型定義（Rust 構造体のミラー）
+│       ├── invoke.ts       #   Tauri IPC ラッパー
+│       ├── style.css       #   グローバルスタイル
+│       ├── components/     #   UI コンポーネント
+│       └── i18n/           #   多言語対応（日本語/英語）
+│
+├── docs/                   # ドキュメント
+│   └── INTENT.md           #   プロダクトビジョン
+│
+├── agent/                  # 自律エージェントワークフロー
+│   ├── loop.sh             #   メインオーケストレーションループ
+│   ├── lib/                #   共通ライブラリ（設定、ログ、Git操作等）
+│   ├── steps/              #   ワークフローステップ（トリアージ→実装→検証→PR）
+│   └── prompts/            #   エージェント用プロンプト
+│
+└── .github/                # GitHub 設定
+    ├── workflows/ci.yml    #   CI パイプライン（Rust + Frontend）
+    └── ISSUE_TEMPLATE/     #   Issue テンプレート
+```
+
+### Cargo ワークスペース構成
+
+本プロジェクトは Cargo ワークスペースで構成されており、2つのメンバークレートを持ちます。
+
+| クレート | パス | 種別 | 説明 |
+|---------|------|------|------|
+| `reown` | `.` (ルート) | ライブラリ | Git/GitHub 操作のコアロジック |
+| `reown-app` | `app/` | バイナリ | Tauri デスクトップアプリ |
+
+### 依存関係
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   frontend/                          │
+│          React + TypeScript + Vite                   │
+│       Tauri IPC (invoke) でコマンド呼び出し            │
+└──────────────────────┬──────────────────────────────┘
+                       │ Tauri IPC
+┌──────────────────────▼──────────────────────────────┐
+│                     app/                             │
+│           Tauri コマンドハンドラ                       │
+│    #[tauri::command] で reown ライブラリを呼び出し      │
+└──────────────────────┬──────────────────────────────┘
+                       │ Rust クレート依存
+┌──────────────────────▼──────────────────────────────┐
+│                     lib/                             │
+│              reown ライブラリ                          │
+│     git2 による Git 操作 / reqwest による GitHub API    │
+└─────────────────────────────────────────────────────┘
+```
+
+**主要な依存クレート:**
+
+- **git2** — libgit2 バインディング（Git 操作）
+- **anyhow** — エラーハンドリング
+- **serde / serde_json** — シリアライゼーション（Tauri IPC）
+- **reqwest** — HTTP クライアント（GitHub API）
+- **tauri** — デスクトップアプリフレームワーク
+
+---
+
 ## セットアップ
 
 ### 前提条件
@@ -37,16 +144,35 @@ mise install
 
 ---
 
-## 使い方
+## ビルド・テスト・開発
+
+### Rust（ライブラリ + アプリ）
 
 ```sh
-# 開発モード（ホットリロード付き）
-cd app && cargo tauri dev
+cargo build                                # ワークスペース全体をビルド
+cargo test                                 # 全テスト実行
+cargo clippy --all-targets -- -D warnings  # リント（警告をエラーとして扱う）
+```
 
-# リリースビルド（.appバンドル生成）
-cd app && cargo tauri build
+### フロントエンド
 
-# ビルドされた.appを起動
+```sh
+cd frontend
+npm ci                  # 依存関係インストール
+npm run dev             # Vite 開発サーバー起動
+npm run build           # TypeScript コンパイル + Vite ビルド
+npm run lint            # ESLint チェック
+npm run typecheck       # TypeScript 型チェック
+npm run format          # Prettier フォーマット
+```
+
+### Tauri アプリ
+
+```sh
+cd app && cargo tauri dev     # 開発モード（ホットリロード付き）
+cd app && cargo tauri build   # リリースビルド（.app バンドル生成）
+
+# ビルドされた .app を起動
 open app/target/release/bundle/macos/reown.app
 ```
 
@@ -56,8 +182,11 @@ open app/target/release/bundle/macos/reown.app
 
 - **言語**: Rust
 - **デスクトップ**: [Tauri 2](https://tauri.app) (macOSネイティブ .app バンドル)
-- **フロントエンド**: HTML / CSS / JavaScript
+- **フロントエンド**: React 19 / TypeScript / [Vite](https://vite.dev) / [TailwindCSS 4](https://tailwindcss.com)
+- **UI**: [Radix UI](https://www.radix-ui.com/) / [i18next](https://www.i18next.com/)（日本語/英語）
 - **Git**: [git2-rs](https://github.com/rust-lang/git2-rs) (libgit2バインディング)
+- **GitHub API**: [reqwest](https://github.com/seanmonstar/reqwest)
+- **CI**: GitHub Actions（Rust ビルド/テスト/clippy + フロントエンド lint/typecheck/build）
 
 ---
 


### PR DESCRIPTION
## Summary

Implements issue #91: [docs] README にプロジェクト構成を整理・追記する

## 概要

README にプロジェクトの構成（ディレクトリ構造、各クレートの役割、ワークスペース構成）を整理して追記する。

## やること

- プロジェクト全体のディレクトリ構造を図示
- 各ディレクトリ（lib / app / frontend）の役割説明
- Cargo ワークスペース構成の説明
- ビルド・テスト・開発のコマンド一覧を現行化
- 依存関係の図（lib → app → frontend の関係）

## 備考

- このissueはドキュメントのタスクです
- ディレクトリリネーム（別issue）の完了後に対応する

Closes #91

---
Generated by agent/loop.sh