### PR TITLE
fix: PR差分をGitHub APIから取得して表示する

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -68,6 +68,18 @@ async fn list_pull_requests(
         .map_err(AppError::github)
 }
 
+#[tauri::command]
+async fn get_pull_request_files(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    token: String,
+) -> Result<Vec<reown::git::diff::FileDiff>, AppError> {
+    reown::github::pull_request::get_pull_request_files(&owner, &repo, pr_number, &token)
+        .await
+        .map_err(AppError::github)
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 
 fn main() {
@@ -82,6 +94,7 @@ fn main() {
             diff_workdir,
             diff_commit,
             list_pull_requests,
+            get_pull_request_files,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -158,10 +171,13 @@ mod tests {
             author: "alice".to_string(),
             state: "open".to_string(),
             head_branch: "feature-x".to_string(),
+            base_branch: "main".to_string(),
             updated_at: "2025-01-15T10:30:00Z".to_string(),
             additions: 100,
             deletions: 20,
             changed_files: 5,
+            body: "PR description".to_string(),
+            html_url: "https://github.com/owner/repo/pull/42".to_string(),
         };
         let json = serde_json::to_value(&pr).unwrap();
         assert_eq!(json["number"], 42);
@@ -169,9 +185,12 @@ mod tests {
         assert_eq!(json["author"], "alice");
         assert_eq!(json["state"], "open");
         assert_eq!(json["head_branch"], "feature-x");
+        assert_eq!(json["base_branch"], "main");
         assert_eq!(json["additions"], 100);
         assert_eq!(json["deletions"], 20);
         assert_eq!(json["changed_files"], 5);
+        assert_eq!(json["body"], "PR description");
+        assert_eq!(json["html_url"], "https://github.com/owner/repo/pull/42");
     }
 
     #[test]

--- a/frontend/src/components/PrTab.tsx
+++ b/frontend/src/components/PrTab.tsx
@@ -1,9 +1,10 @@
 import { useState, FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "../invoke";
-import type { PrInfo } from "../types";
+import type { PrInfo, FileDiff } from "../types";
 import { Badge } from "./Badge";
 import { Button } from "./Button";
+import { Card } from "./Card";
 import { Input } from "./Input";
 import { Loading } from "./Loading";
 
@@ -22,6 +23,45 @@ function stateVariant(
   }
 }
 
+function statusLabel(status: string): string {
+  switch (status) {
+    case "Added":
+      return "A";
+    case "Deleted":
+      return "D";
+    case "Modified":
+      return "M";
+    case "Renamed":
+      return "R";
+    default:
+      return "?";
+  }
+}
+
+function statusVariant(
+  status: string,
+): "success" | "danger" | "warning" | "info" | "default" {
+  switch (status) {
+    case "Added":
+      return "success";
+    case "Deleted":
+      return "danger";
+    case "Modified":
+      return "warning";
+    case "Renamed":
+      return "info";
+    default:
+      return "default";
+  }
+}
+
+function getOriginString(
+  origin: "Addition" | "Deletion" | "Context" | { Other: string },
+): string {
+  if (typeof origin === "string") return origin;
+  return "Other";
+}
+
 export function PrTab() {
   const { t } = useTranslation();
   const [owner, setOwner] = useState("");
@@ -31,6 +71,12 @@ export function PrTab() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+
+  const [selectedPr, setSelectedPr] = useState<PrInfo | null>(null);
+  const [diffs, setDiffs] = useState<FileDiff[]>([]);
+  const [selectedFileIndex, setSelectedFileIndex] = useState(-1);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
 
   async function handleLoad(e?: FormEvent) {
     e?.preventDefault();
@@ -42,6 +88,9 @@ export function PrTab() {
     setFormError(null);
     setError(null);
     setLoading(true);
+    setSelectedPr(null);
+    setDiffs([]);
+    setSelectedFileIndex(-1);
     try {
       const result = await invoke("list_pull_requests", {
         owner: owner.trim(),
@@ -56,6 +105,166 @@ export function PrTab() {
     }
   }
 
+  async function handleSelectPr(pr: PrInfo) {
+    setSelectedPr(pr);
+    setDiffError(null);
+    setDiffLoading(true);
+    setDiffs([]);
+    setSelectedFileIndex(-1);
+    try {
+      const result = await invoke("get_pull_request_files", {
+        owner: owner.trim(),
+        repo: repo.trim(),
+        prNumber: pr.number,
+        token: token.trim(),
+      });
+      setDiffs(result);
+      if (result.length > 0) {
+        setSelectedFileIndex(0);
+      }
+    } catch (err) {
+      setDiffError(String(err));
+    } finally {
+      setDiffLoading(false);
+    }
+  }
+
+  function handleBackToList() {
+    setSelectedPr(null);
+    setDiffs([]);
+    setSelectedFileIndex(-1);
+    setDiffError(null);
+  }
+
+  const selectedDiff =
+    selectedFileIndex >= 0 ? diffs[selectedFileIndex] : null;
+
+  // PR diff view
+  if (selectedPr) {
+    return (
+      <div>
+        <div className="mb-4 flex items-center gap-3">
+          <Button onClick={handleBackToList}>{t("pr.backToList")}</Button>
+          <span className="font-mono text-[0.8rem] font-semibold text-info">
+            #{selectedPr.number}
+          </span>
+          <span className="text-[0.9rem] font-medium text-text-primary">
+            {selectedPr.title}
+          </span>
+          <Badge variant={stateVariant(selectedPr.state)}>
+            {selectedPr.state}
+          </Badge>
+        </div>
+        <div className="grid min-h-[500px] grid-cols-[280px_1fr] gap-4">
+          <Card className="flex flex-col">
+            <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+              {t("diff.changedFiles")}
+            </h2>
+            <div className="scrollbar-custom flex-1 overflow-y-auto">
+              {diffLoading && <Loading />}
+              {diffError && (
+                <p className="p-2 text-[0.9rem] text-danger">
+                  {t("common.error", { message: diffError })}
+                </p>
+              )}
+              {!diffLoading && !diffError && diffs.length === 0 && (
+                <p className="p-2 text-[0.9rem] italic text-text-secondary">
+                  {t("pr.noDiffFiles")}
+                </p>
+              )}
+              {diffs.map((diff, index) => (
+                <div
+                  key={diff.new_path ?? diff.old_path ?? index}
+                  className={`flex cursor-pointer items-center gap-2 border-b border-border px-3 py-1.5 font-mono text-[0.8rem] transition-colors last:border-b-0 hover:bg-bg-primary ${
+                    selectedFileIndex === index
+                      ? "border-l-2 border-l-accent bg-bg-hover"
+                      : ""
+                  }`}
+                  onClick={() => setSelectedFileIndex(index)}
+                >
+                  <Badge variant={statusVariant(diff.status)}>
+                    {statusLabel(diff.status)}
+                  </Badge>
+                  <span
+                    className="truncate text-text-primary"
+                    title={diff.new_path ?? diff.old_path ?? ""}
+                  >
+                    {diff.new_path ?? diff.old_path ?? "(unknown)"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Card>
+          <Card className="flex flex-col overflow-hidden">
+            <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+              {selectedDiff
+                ? (selectedDiff.new_path ?? selectedDiff.old_path ?? "Diff")
+                : "Diff"}
+            </h2>
+            <div className="scrollbar-custom flex-1 overflow-auto font-mono text-[0.8rem] leading-relaxed">
+              {!selectedDiff && (
+                <p className="p-2 text-[0.9rem] italic text-text-secondary">
+                  {t("diff.selectFile")}
+                </p>
+              )}
+              {selectedDiff && selectedDiff.chunks.length === 0 && (
+                <p className="p-2 text-[0.9rem] italic text-text-secondary">
+                  {t("diff.noDiffContent")}
+                </p>
+              )}
+              {selectedDiff?.chunks.map((chunk, ci) => (
+                <div key={ci}>
+                  <div className="border-y border-border bg-diff-header-bg px-3 py-1 text-xs text-info">
+                    {chunk.header}
+                  </div>
+                  {chunk.lines.map((line, li) => {
+                    const origin = getOriginString(line.origin);
+                    const lineClass =
+                      origin === "Addition"
+                        ? "diff-line-addition"
+                        : origin === "Deletion"
+                          ? "diff-line-deletion"
+                          : "";
+                    const prefix =
+                      origin === "Addition"
+                        ? "+"
+                        : origin === "Deletion"
+                          ? "-"
+                          : " ";
+                    const textColor =
+                      origin === "Addition"
+                        ? "text-accent"
+                        : origin === "Deletion"
+                          ? "text-danger"
+                          : "text-text-secondary";
+                    return (
+                      <div
+                        key={li}
+                        className={`flex whitespace-pre ${lineClass}`}
+                      >
+                        <span className="inline-block min-w-[3.5em] shrink-0 select-none px-2 text-right text-text-muted">
+                          {line.old_lineno ?? ""}
+                        </span>
+                        <span className="inline-block min-w-[3.5em] shrink-0 select-none px-2 text-right text-text-muted">
+                          {line.new_lineno ?? ""}
+                        </span>
+                        <span className={`flex-1 px-2 ${textColor}`}>
+                          {prefix}
+                          {line.content}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // PR list view
   return (
     <div>
       <section className="flex flex-col rounded-lg border border-border bg-bg-secondary p-5">
@@ -124,7 +333,8 @@ export function PrTab() {
           {prs.map((pr) => (
             <div
               key={pr.number}
-              className="border-b border-border px-3 py-3 last:border-b-0"
+              className="cursor-pointer border-b border-border px-3 py-3 transition-colors last:border-b-0 hover:bg-bg-hover"
+              onClick={() => handleSelectPr(pr)}
             >
               <div className="mb-1 flex items-center gap-2">
                 <a
@@ -132,6 +342,7 @@ export function PrTab() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-mono text-[0.8rem] font-semibold text-info hover:underline"
+                  onClick={(e) => e.stopPropagation()}
                 >
                   #{pr.number}
                 </a>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -57,6 +57,8 @@
     "fetch": "Fetch",
     "fillAllFields": "Please fill in all fields.",
     "empty": "Enter the form above to fetch PR information.",
-    "files": "{{count}} files"
+    "files": "{{count}} files",
+    "backToList": "← Back to list",
+    "noDiffFiles": "No changed files."
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -57,6 +57,8 @@
     "fetch": "取得",
     "fillAllFields": "全てのフィールドを入力してください。",
     "empty": "PR情報を取得するには上のフォームに入力してください。",
-    "files": "{{count}} files"
+    "files": "{{count}} files",
+    "backToList": "← 一覧に戻る",
+    "noDiffFiles": "変更ファイルがありません。"
   }
 }

--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -17,6 +17,10 @@ type Commands = {
     args: { owner: string; repo: string; token: string };
     ret: PrInfo[];
   };
+  get_pull_request_files: {
+    args: { owner: string; repo: string; prNumber: number; token: string };
+    ret: FileDiff[];
+  };
 };
 
 export async function invoke<C extends keyof Commands>(

--- a/lib/github/mod.rs
+++ b/lib/github/mod.rs
@@ -4,5 +4,6 @@ pub mod pull_request;
 pub mod types;
 
 pub use pull_request::PrInfo;
+pub use pull_request::get_pull_request_files;
 #[allow(unused_imports)]
 pub use types::PullRequest;

--- a/lib/github/pull_request.rs
+++ b/lib/github/pull_request.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::git::diff::{DiffChunk, DiffLineInfo, FileDiff, FileStatus, LineOrigin};
+
 /// Information about a GitHub pull request.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PrInfo {
@@ -84,6 +86,9 @@ impl From<GhPullRequest> for PrInfo {
 /// Maximum number of pages to fetch to prevent infinite loops.
 const MAX_PAGES: u32 = 10;
 
+/// Maximum number of pages when fetching PR files (300 files / 100 per page).
+const MAX_FILE_PAGES: u32 = 3;
+
 /// Parse the `Link` header to check if a `rel="next"` link exists.
 fn has_next_page(link_header: &str) -> bool {
     link_header
@@ -141,6 +146,204 @@ pub async fn list_pull_requests(owner: &str, repo: &str, token: &str) -> Result<
     }
 
     Ok(all_prs)
+}
+
+/// Raw GitHub API response for a single file in a pull request.
+#[derive(Debug, Deserialize)]
+struct GhPullRequestFile {
+    filename: String,
+    status: String,
+    #[serde(default)]
+    previous_filename: Option<String>,
+    #[serde(default)]
+    patch: Option<String>,
+}
+
+/// Parse a unified diff patch string into `DiffChunk`s.
+fn parse_patch(patch: &str) -> Vec<DiffChunk> {
+    let mut chunks = Vec::new();
+    let mut current_chunk: Option<DiffChunk> = None;
+
+    for line in patch.lines() {
+        if line.starts_with("@@") {
+            if let Some(chunk) = current_chunk.take() {
+                chunks.push(chunk);
+            }
+            current_chunk = Some(DiffChunk {
+                header: line.to_string(),
+                lines: Vec::new(),
+            });
+
+            // Parse hunk header to get starting line numbers
+            // Format: @@ -old_start,old_count +new_start,new_count @@
+            continue;
+        }
+
+        if let Some(chunk) = current_chunk.as_mut() {
+            let (origin, content) = if let Some(rest) = line.strip_prefix('+') {
+                (LineOrigin::Addition, rest)
+            } else if let Some(rest) = line.strip_prefix('-') {
+                (LineOrigin::Deletion, rest)
+            } else if let Some(rest) = line.strip_prefix(' ') {
+                (LineOrigin::Context, rest)
+            } else {
+                // Lines without a prefix (e.g. "\ No newline at end of file")
+                (LineOrigin::Context, line)
+            };
+
+            chunk.lines.push(DiffLineInfo {
+                origin,
+                old_lineno: None,
+                new_lineno: None,
+                content: format!("{content}\n"),
+            });
+        }
+    }
+
+    if let Some(chunk) = current_chunk {
+        chunks.push(chunk);
+    }
+
+    // Assign line numbers based on hunk headers
+    for chunk in &mut chunks {
+        let (mut old_line, mut new_line) = parse_hunk_header(&chunk.header);
+        for line in &mut chunk.lines {
+            match line.origin {
+                LineOrigin::Addition => {
+                    line.new_lineno = Some(new_line);
+                    new_line += 1;
+                }
+                LineOrigin::Deletion => {
+                    line.old_lineno = Some(old_line);
+                    old_line += 1;
+                }
+                LineOrigin::Context | LineOrigin::Other(_) => {
+                    line.old_lineno = Some(old_line);
+                    line.new_lineno = Some(new_line);
+                    old_line += 1;
+                    new_line += 1;
+                }
+            }
+        }
+    }
+
+    chunks
+}
+
+/// Parse a hunk header like `@@ -1,3 +1,4 @@` to extract (old_start, new_start).
+fn parse_hunk_header(header: &str) -> (u32, u32) {
+    // Strip @@ prefix/suffix and split
+    let trimmed = header.trim_start_matches('@').trim().split("@@").next().unwrap_or("");
+    let mut old_start = 1u32;
+    let mut new_start = 1u32;
+
+    for part in trimmed.split_whitespace() {
+        if let Some(rest) = part.strip_prefix('-') {
+            if let Some(start) = rest.split(',').next() {
+                old_start = start.parse().unwrap_or(1);
+            }
+        } else if let Some(rest) = part.strip_prefix('+') {
+            if let Some(start) = rest.split(',').next() {
+                new_start = start.parse().unwrap_or(1);
+            }
+        }
+    }
+
+    (old_start, new_start)
+}
+
+impl GhPullRequestFile {
+    fn into_file_diff(self) -> FileDiff {
+        let status = match self.status.as_str() {
+            "added" => FileStatus::Added,
+            "removed" => FileStatus::Deleted,
+            "modified" | "changed" => FileStatus::Modified,
+            "renamed" => FileStatus::Renamed,
+            _ => FileStatus::Other,
+        };
+
+        let chunks = self
+            .patch
+            .as_deref()
+            .map(parse_patch)
+            .unwrap_or_default();
+
+        let old_path = match &status {
+            FileStatus::Added => None,
+            FileStatus::Renamed => self.previous_filename.clone(),
+            _ => Some(self.filename.clone()),
+        };
+
+        let new_path = match &status {
+            FileStatus::Deleted => None,
+            _ => Some(self.filename),
+        };
+
+        FileDiff {
+            old_path,
+            new_path,
+            status,
+            chunks,
+        }
+    }
+}
+
+/// Fetch the list of changed files for a pull request from GitHub API.
+///
+/// Calls `GET /repos/{owner}/{repo}/pulls/{pr_number}/files` and converts
+/// the response into `Vec<FileDiff>`. Paginates up to 300 files (3 pages).
+pub async fn get_pull_request_files(
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+) -> Result<Vec<FileDiff>> {
+    let client = reqwest::Client::new();
+    let mut all_files = Vec::new();
+
+    for page in 1..=MAX_FILE_PAGES {
+        let url = format!(
+            "https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/files?per_page=100&page={page}"
+        );
+
+        let response = client
+            .get(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {token}"))
+            .header("User-Agent", "reown")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .with_context(|| {
+                format!("Failed to fetch PR #{pr_number} files from {owner}/{repo} (page {page})")
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub API returned {status}: {body}");
+        }
+
+        let has_next = response
+            .headers()
+            .get("link")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(has_next_page);
+
+        let files: Vec<GhPullRequestFile> = response
+            .json()
+            .await
+            .context("Failed to parse GitHub PR files response")?;
+
+        let is_empty = files.is_empty();
+        all_files.extend(files.into_iter().map(GhPullRequestFile::into_file_diff));
+
+        if is_empty || !has_next {
+            break;
+        }
+    }
+
+    Ok(all_files)
 }
 
 #[cfg(test)]
@@ -397,5 +600,159 @@ mod tests {
         assert_eq!(prs[0].state, "open");
         assert_eq!(prs[1].state, "closed");
         assert_eq!(prs[2].state, "merged");
+    }
+
+    /// Test parsing a unified diff patch into DiffChunks.
+    #[test]
+    fn test_parse_patch_basic() {
+        let patch = "@@ -1,3 +1,4 @@\n context line\n-removed line\n+added line\n+new line";
+        let chunks = parse_patch(patch);
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].header, "@@ -1,3 +1,4 @@");
+        assert_eq!(chunks[0].lines.len(), 4);
+
+        assert_eq!(chunks[0].lines[0].origin, LineOrigin::Context);
+        assert_eq!(chunks[0].lines[0].old_lineno, Some(1));
+        assert_eq!(chunks[0].lines[0].new_lineno, Some(1));
+
+        assert_eq!(chunks[0].lines[1].origin, LineOrigin::Deletion);
+        assert_eq!(chunks[0].lines[1].old_lineno, Some(2));
+        assert!(chunks[0].lines[1].new_lineno.is_none());
+
+        assert_eq!(chunks[0].lines[2].origin, LineOrigin::Addition);
+        assert!(chunks[0].lines[2].old_lineno.is_none());
+        assert_eq!(chunks[0].lines[2].new_lineno, Some(2));
+
+        assert_eq!(chunks[0].lines[3].origin, LineOrigin::Addition);
+        assert!(chunks[0].lines[3].old_lineno.is_none());
+        assert_eq!(chunks[0].lines[3].new_lineno, Some(3));
+    }
+
+    /// Test parsing a patch with multiple hunks.
+    #[test]
+    fn test_parse_patch_multiple_hunks() {
+        let patch = "@@ -1,2 +1,2 @@\n-old\n+new\n@@ -10,2 +10,3 @@\n context\n+added\n context";
+        let chunks = parse_patch(patch);
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].lines.len(), 2);
+        assert_eq!(chunks[1].lines.len(), 3);
+        assert_eq!(chunks[1].header, "@@ -10,2 +10,3 @@");
+
+        // Second hunk starts at line 10
+        assert_eq!(chunks[1].lines[0].old_lineno, Some(10));
+        assert_eq!(chunks[1].lines[0].new_lineno, Some(10));
+    }
+
+    /// Test parsing an empty patch.
+    #[test]
+    fn test_parse_patch_empty() {
+        let chunks = parse_patch("");
+        assert!(chunks.is_empty());
+    }
+
+    /// Test hunk header parsing.
+    #[test]
+    fn test_parse_hunk_header() {
+        assert_eq!(parse_hunk_header("@@ -1,3 +1,4 @@"), (1, 1));
+        assert_eq!(parse_hunk_header("@@ -10,5 +20,8 @@"), (10, 20));
+        assert_eq!(parse_hunk_header("@@ -1 +1 @@"), (1, 1));
+        assert_eq!(parse_hunk_header("@@ -100,3 +200,5 @@ fn main()"), (100, 200));
+    }
+
+    /// Test GitHub PR file response deserialization.
+    #[test]
+    fn test_parse_pr_files_response() {
+        let json = r#"[
+            {
+                "filename": "src/main.rs",
+                "status": "modified",
+                "patch": "@@ -1,3 +1,4 @@\n fn main() {\n+    println!(\"hello\");\n }"
+            },
+            {
+                "filename": "src/new.rs",
+                "status": "added",
+                "patch": "@@ -0,0 +1,2 @@\n+line1\n+line2"
+            }
+        ]"#;
+
+        let files: Vec<GhPullRequestFile> = serde_json::from_str(json).unwrap();
+        let diffs: Vec<FileDiff> = files.into_iter().map(GhPullRequestFile::into_file_diff).collect();
+
+        assert_eq!(diffs.len(), 2);
+
+        assert_eq!(diffs[0].new_path.as_deref(), Some("src/main.rs"));
+        assert_eq!(diffs[0].old_path.as_deref(), Some("src/main.rs"));
+        assert_eq!(diffs[0].status, FileStatus::Modified);
+        assert!(!diffs[0].chunks.is_empty());
+
+        assert_eq!(diffs[1].new_path.as_deref(), Some("src/new.rs"));
+        assert!(diffs[1].old_path.is_none());
+        assert_eq!(diffs[1].status, FileStatus::Added);
+    }
+
+    /// Test file status mapping from GitHub API statuses.
+    #[test]
+    fn test_file_status_mapping() {
+        let make_file = |status: &str| GhPullRequestFile {
+            filename: "test.rs".to_string(),
+            status: status.to_string(),
+            previous_filename: None,
+            patch: None,
+        };
+
+        assert_eq!(make_file("added").into_file_diff().status, FileStatus::Added);
+        assert_eq!(make_file("removed").into_file_diff().status, FileStatus::Deleted);
+        assert_eq!(make_file("modified").into_file_diff().status, FileStatus::Modified);
+        assert_eq!(make_file("changed").into_file_diff().status, FileStatus::Modified);
+        assert_eq!(make_file("renamed").into_file_diff().status, FileStatus::Renamed);
+        assert_eq!(make_file("copied").into_file_diff().status, FileStatus::Other);
+    }
+
+    /// Test renamed file uses previous_filename for old_path.
+    #[test]
+    fn test_renamed_file_paths() {
+        let file = GhPullRequestFile {
+            filename: "new_name.rs".to_string(),
+            status: "renamed".to_string(),
+            previous_filename: Some("old_name.rs".to_string()),
+            patch: None,
+        };
+
+        let diff = file.into_file_diff();
+        assert_eq!(diff.old_path.as_deref(), Some("old_name.rs"));
+        assert_eq!(diff.new_path.as_deref(), Some("new_name.rs"));
+        assert_eq!(diff.status, FileStatus::Renamed);
+    }
+
+    /// Test deleted file has no new_path.
+    #[test]
+    fn test_deleted_file_paths() {
+        let file = GhPullRequestFile {
+            filename: "removed.rs".to_string(),
+            status: "removed".to_string(),
+            previous_filename: None,
+            patch: None,
+        };
+
+        let diff = file.into_file_diff();
+        assert_eq!(diff.old_path.as_deref(), Some("removed.rs"));
+        assert!(diff.new_path.is_none());
+        assert_eq!(diff.status, FileStatus::Deleted);
+    }
+
+    /// Test file without patch (e.g. binary file) has empty chunks.
+    #[test]
+    fn test_file_without_patch() {
+        let file = GhPullRequestFile {
+            filename: "image.png".to_string(),
+            status: "added".to_string(),
+            previous_filename: None,
+            patch: None,
+        };
+
+        let diff = file.into_file_diff();
+        assert!(diff.chunks.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #127: PR差分をGitHub APIから取得して表示する

## 概要

PRリストからPRを選択した際に、そのPRの差分（変更ファイル一覧とdiff）をアプリ内で表示できるようにする。これにより、ブラウザに切り替えることなくPRの変更内容を確認できるようになる。

## 前提

- `PrInfo` に `html_url`, `body`, `base_branch` が追加済みであること（前のIssue）

## 実装内容

### Rust (lib/github/pull_request.rs)
- `get_pull_request_files(owner, repo, pr_number, token)` 関数を追加
- GitHub API `GET /repos/{owner}/{repo}/pulls/{pr_number}/files` を呼び出す
- レスポンスを既存の `FileDiff` / `DiffChunk` 構造体に変換する（または互換型を作成）
- ページネーション対応（最大300ファイル）

### Tauri (app/src/main.rs)
- `get_pull_request_files` コマンドを追加
- `tauri::generate_handler![]` に登録

### フロントエンド
- PrTab でPRをクリックすると差分ファイル一覧を表示
- 既存の DiffTab のdiff表示コンポーネントを再利用して差分を表示

## Acceptance Criteria

- [ ] `get_pull_request_files()` がGitHub APIからPRの変更ファイルを取得できる
- [ ] 取得した差分がフロントエンドで表示される
- [ ] PRリストからPRをクリックすると差分ビューに遷移する
- [ ] `cargo test` が全てパスする
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #127

---
Generated by agent/loop.sh