### PR TITLE
fix: PRのコミット一覧を取得して表示する

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,6 +59,8 @@
     "empty": "Enter the form above to fetch PR information.",
     "files": "{{count}} files",
     "backToList": "← Back to list",
-    "noDiffFiles": "No changed files."
+    "noDiffFiles": "No changed files.",
+    "commits": "Commits",
+    "noCommits": "No commits."
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -59,6 +59,8 @@
     "empty": "PR情報を取得するには上のフォームに入力してください。",
     "files": "{{count}} files",
     "backToList": "← 一覧に戻る",
-    "noDiffFiles": "変更ファイルがありません。"
+    "noDiffFiles": "変更ファイルがありません。",
+    "commits": "コミット",
+    "noCommits": "コミットがありません。"
   }
 }

--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -1,5 +1,5 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
-import type { WorktreeInfo, BranchInfo, FileDiff, PrInfo } from "./types";
+import type { WorktreeInfo, BranchInfo, FileDiff, PrInfo, CommitInfo } from "./types";
 
 type Commands = {
   list_worktrees: { args?: Record<string, unknown>; ret: WorktreeInfo[] };
@@ -20,6 +20,10 @@ type Commands = {
   get_pull_request_files: {
     args: { owner: string; repo: string; prNumber: number; token: string };
     ret: FileDiff[];
+  };
+  list_pr_commits: {
+    args: { owner: string; repo: string; prNumber: number; token: string };
+    ret: CommitInfo[];
   };
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,6 +31,13 @@ export interface FileDiff {
   chunks: DiffChunk[];
 }
 
+export interface CommitInfo {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
 export interface PrInfo {
   number: number;
   title: string;

--- a/lib/github/mod.rs
+++ b/lib/github/mod.rs
@@ -3,6 +3,7 @@ pub mod pull_request;
 #[allow(dead_code)]
 pub mod types;
 
+pub use pull_request::CommitInfo;
 pub use pull_request::PrInfo;
 pub use pull_request::get_pull_request_files;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

Implements issue #130: PRのコミット一覧を取得して表示する

## 概要

PRのレビューを行うためには、PR内の個々のコミットを確認できることが重要です。GitHub APIからPRのコミット一覧を取得し、PRタブ内でコミットリストを表示する機能を追加します。

これにより、変更をコミット単位で追跡でき、レビューの粒度を細かくすることができます。

## 実装内容

### Rust ライブラリ (`lib/github/`)
- `CommitInfo` 構造体を追加（sha, message, author, date）
- `list_pr_commits(owner, repo, pr_number, token)` 関数を追加
- GitHub API `GET /repos/{owner}/{repo}/pulls/{number}/commits` を呼び出す

### Tauri コマンド (`app/src/main.rs`)
- `list_pr_commits` コマンドを追加

### フロントエンド (`frontend/src/`)
- `CommitInfo` 型を `types.ts` に追加
- PRをクリックした時にコミット一覧を表示するUI（展開パネル or サイドパネル）

## Acceptance Criteria

- [ ] `CommitInfo` 構造体（sha, message, author, date）が定義されている
- [ ] `list_pr_commits()` がGitHub APIからコミット一覧を取得できる
- [ ] Tauri コマンドとしてフロントエンドから呼び出せる
- [ ] PR行をクリックするとコミット一覧が表示される
- [ ] `cargo test` と `cargo clippy` がパスする

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #130

---
Generated by agent/loop.sh