### PR TITLE
chore: chore: コンパイル warning の撲滅

### DIFF
--- a/app/src/error.rs
+++ b/app/src/error.rs
@@ -19,9 +19,8 @@ pub enum ErrorKind {
     /// リポジトリが見つからない、またはGit操作の失敗
     Git,
     /// GitHub APIのネットワークエラーやHTTPエラー
+    #[serde(rename = "github")]
     GitHub,
-    /// その他の内部エラー
-    Internal,
 }
 
 impl std::fmt::Display for AppError {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -240,7 +240,6 @@ mod tests {
         for (kind, expected) in [
             (ErrorKind::Git, "git"),
             (ErrorKind::GitHub, "github"),
-            (ErrorKind::Internal, "internal"),
         ] {
             let json = serde_json::to_value(&kind).unwrap();
             assert_eq!(json, expected);


### PR DESCRIPTION
## Summary

Implements issue #137: chore: コンパイル warning の撲滅

## 概要

ビルド時に発生する warning を解消する。

## 現状の warning

- `ErrorKind::Internal` が未使用 (`app/src/error.rs:24`)

## 要件

- `cargo build` で warning が 0 になること
- `cargo clippy --all-targets -- -D warnings` が通ること

Closes #137

---
Generated by agent/loop.sh