### PR TITLE
feat: feat: サイドメニューレイアウトの導入とリポジトリ一覧表示

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { Sidebar } from "./Sidebar";
+import { TabBar } from "./TabBar";
+import type { RepositoryEntry } from "../types";
 
 interface NavItem {
   id: string;
@@ -8,19 +11,57 @@ interface NavItem {
 }
 
 interface Props {
+  repositories: RepositoryEntry[];
+  selectedRepoPath: string | null;
+  onSelectRepo: (path: string) => void;
+  onAddRepo: () => void;
+  onRemoveRepo: (path: string) => void;
   navItems: NavItem[];
-  activeId: string;
-  onSelect: (id: string) => void;
+  activeTabId: string;
+  onSelectTab: (id: string) => void;
   children: ReactNode;
 }
 
-export function Layout({ navItems, activeId, onSelect, children }: Props) {
+export function Layout({
+  repositories,
+  selectedRepoPath,
+  onSelectRepo,
+  onAddRepo,
+  onRemoveRepo,
+  navItems,
+  activeTabId,
+  onSelectTab,
+  children,
+}: Props) {
+  const { t } = useTranslation();
+
   return (
     <div className="flex h-screen overflow-hidden bg-bg-primary">
-      <Sidebar items={navItems} activeId={activeId} onSelect={onSelect} />
-      <main className="scrollbar-custom flex-1 overflow-y-auto p-6">
-        {children}
-      </main>
+      <Sidebar
+        repositories={repositories}
+        selectedPath={selectedRepoPath}
+        onSelect={onSelectRepo}
+        onAdd={onAddRepo}
+        onRemove={onRemoveRepo}
+      />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {selectedRepoPath ? (
+          <>
+            <TabBar
+              items={navItems}
+              activeId={activeTabId}
+              onSelect={onSelectTab}
+            />
+            <main className="scrollbar-custom flex-1 overflow-y-auto p-6">
+              {children}
+            </main>
+          </>
+        ) : (
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-text-muted">{t("repository.selectPrompt")}</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,18 +1,21 @@
 import { useTranslation } from "react-i18next";
-
-interface NavItem {
-  id: string;
-  labelKey: string;
-  shortcut: string;
-}
+import type { RepositoryEntry } from "../types";
 
 interface Props {
-  items: NavItem[];
-  activeId: string;
-  onSelect: (id: string) => void;
+  repositories: RepositoryEntry[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onAdd: () => void;
+  onRemove: (path: string) => void;
 }
 
-export function Sidebar({ items, activeId, onSelect }: Props) {
+export function Sidebar({
+  repositories,
+  selectedPath,
+  onSelect,
+  onAdd,
+  onRemove,
+}: Props) {
   const { t } = useTranslation();
 
   return (
@@ -20,24 +23,55 @@ export function Sidebar({ items, activeId, onSelect }: Props) {
       <div className="flex items-center gap-2 border-b border-border px-4 py-3">
         <h1 className="text-lg font-bold text-white">{t("app.title")}</h1>
       </div>
-      <nav className="flex-1 overflow-y-auto py-2">
-        {items.map((item) => (
-          <button
-            key={item.id}
-            onClick={() => onSelect(item.id)}
-            className={`flex w-full cursor-pointer items-center justify-between border-none px-4 py-2 text-left text-[0.85rem] transition-colors ${
-              activeId === item.id
-                ? "border-l-2 border-l-accent bg-bg-hover text-accent"
-                : "bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
-            }`}
-          >
-            <span>{t(item.labelKey)}</span>
-            <kbd className="rounded border border-border-hover bg-bg-hint px-1.5 text-[0.65rem] text-text-muted">
-              {item.shortcut}
-            </kbd>
-          </button>
-        ))}
+      <div className="border-b border-border px-4 py-2">
+        <span className="text-[0.7rem] font-semibold uppercase tracking-wider text-text-muted">
+          {t("repository.title")}
+        </span>
+      </div>
+      <nav className="scrollbar-custom flex-1 overflow-y-auto py-1">
+        {repositories.length === 0 ? (
+          <p className="px-4 py-3 text-[0.75rem] text-text-muted">
+            {t("repository.empty")}
+          </p>
+        ) : (
+          repositories.map((repo) => (
+            <div
+              key={repo.path}
+              className={`group flex w-full items-center justify-between px-4 py-2 text-[0.85rem] transition-colors ${
+                selectedPath === repo.path
+                  ? "border-l-2 border-l-accent bg-bg-hover text-accent"
+                  : "border-l-2 border-l-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+              }`}
+            >
+              <button
+                className="flex-1 cursor-pointer truncate border-none bg-transparent text-left text-inherit"
+                onClick={() => onSelect(repo.path)}
+                title={repo.path}
+              >
+                {repo.name}
+              </button>
+              <button
+                className="ml-1 cursor-pointer border-none bg-transparent p-0.5 text-text-muted opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(repo.path);
+                }}
+                title={t("repository.remove")}
+              >
+                ✕
+              </button>
+            </div>
+          ))
+        )}
       </nav>
+      <div className="border-t border-border px-3 py-2">
+        <button
+          onClick={onAdd}
+          className="flex w-full cursor-pointer items-center justify-center gap-1 rounded border border-border bg-transparent px-3 py-1.5 text-[0.8rem] text-text-secondary transition-colors hover:border-accent hover:text-accent"
+        >
+          + {t("repository.add")}
+        </button>
+      </div>
       <div className="border-t border-border px-4 py-3">
         <p className="text-[0.7rem] text-text-muted">{t("app.tagline")}</p>
       </div>

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "react-i18next";
+
+interface NavItem {
+  id: string;
+  labelKey: string;
+  shortcut: string;
+}
+
+interface Props {
+  items: NavItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
+}
+
+export function TabBar({ items, activeId, onSelect }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex border-b border-border bg-bg-secondary">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          onClick={() => onSelect(item.id)}
+          className={`cursor-pointer border-none px-4 py-2 text-[0.85rem] transition-colors ${
+            activeId === item.id
+              ? "border-b-2 border-b-accent bg-transparent text-accent"
+              : "border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          }`}
+        >
+          <span>{t(item.labelKey)}</span>
+          <kbd className="ml-2 rounded border border-border-hover bg-bg-hint px-1.5 text-[0.6rem] text-text-muted">
+            {item.shortcut}
+          </kbd>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3,6 +3,14 @@
     "title": "reown",
     "tagline": "Own your codebase, even in the age of agent PR storms."
   },
+  "repository": {
+    "title": "Repositories",
+    "add": "Add Repository",
+    "remove": "Remove",
+    "confirmRemove": "Remove repository '{{name}}' from the list?",
+    "selectPrompt": "Select a repository from the sidebar.",
+    "empty": "No repositories registered. Click \"Add Repository\" to get started."
+  },
   "tabs": {
     "worktrees": "Worktrees",
     "branches": "Branches",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -3,6 +3,14 @@
     "title": "reown",
     "tagline": "エージェントPRの嵐の時代でも、コードベースを自分のものに。"
   },
+  "repository": {
+    "title": "リポジトリ",
+    "add": "リポジトリを追加",
+    "remove": "削除",
+    "confirmRemove": "リポジトリ '{{name}}' を一覧から削除しますか？",
+    "selectPrompt": "左のサイドメニューからリポジトリを選択してください。",
+    "empty": "リポジトリが登録されていません。「リポジトリを追加」から追加してください。"
+  },
   "tabs": {
     "worktrees": "Worktrees",
     "branches": "Branches",


### PR DESCRIPTION
## Summary

Implements issue #140: feat: サイドメニューレイアウトの導入とリポジトリ一覧表示

## 概要

現在のサイドバー（タブナビゲーション）をリポジトリ一覧のサイドメニューに変更し、タブナビゲーションを右側コンテンツ領域の上部に移動するレイアウト変更を行う。

## 要件

- 左側サイドメニューにリポジトリ一覧を表示する
  - リポジトリ名をクリックで選択状態にする
  - 「リポジトリを追加」ボタンを配置する（#136 の add_repository コマンドを呼ぶ）
  - リポジトリの削除ボタンを配置する
- 右側コンテンツ領域の上部にタブナビゲーション（Worktree / Branch / Diff / PR）を水平タブとして表示する
- 既存の `Layout.tsx` / `Sidebar.tsx` をリファクタリングする
- リポジトリ未選択時は右側に選択を促すメッセージを表示する

## レイアウト

```
┌──────────┬─────────────────────────────┐
│ repo A   │  [Worktree] [Branch] [Diff] │
│ repo B   │                             │
│ repo C   │   （選択中のrepoの内容）       │
│ [+ 追加] │                             │
└──────────┴─────────────────────────────┘
```

## 受け入れ基準

- [ ] サイドメニューにリポジトリ一覧が表示される
- [ ] サイドメニューからリポジトリの追加・削除ができる
- [ ] タブナビゲーションが右側コンテンツ領域の上部に表示される
- [ ] リポジトリ未選択時に適切なメッセージが表示される
- [ ] 既存のキーボードショートカット（W/B/D/P/Tab）が引き続き動作する

Parent: #136

Closes #140

---
Generated by agent/loop.sh