### PR TITLE
feat: issueを保護しrepoを公開できるようにする

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,2 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links: []

--- a/.github/workflows/issue-guard.yml
+++ b/.github/workflows/issue-guard.yml
@@ -1,0 +1,24 @@
+name: Issue Guard
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue if not from allowed author
+        if: github.event.issue.user.login != 'xiangma9712'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --body "このリポジトリでは、許可されたユーザーのみがIssueを作成できます。このIssueは自動的にクローズされます。"
+          gh issue close "$ISSUE_NUMBER" --repo "$REPO"

--- a/agent/lib/00_config.sh
+++ b/agent/lib/00_config.sh
@@ -18,3 +18,4 @@ VALIDATE_DIFF_MAX_TURNS="${VALIDATE_DIFF_MAX_TURNS:-10}"
 PROPOSE_MAX_TURNS="${PROPOSE_MAX_TURNS:-10}"
 LOG_MAX_BYTES="${LOG_MAX_BYTES:-524288}"       # 512KB per file
 LOG_MAX_FILES="${LOG_MAX_FILES:-3}"             # keep progress.txt + 3 archives
+ALLOWED_ISSUE_AUTHOR="${ALLOWED_ISSUE_AUTHOR:-xiangma9712}"  # only process issues from this author

--- a/agent/steps/01_setup.sh
+++ b/agent/steps/01_setup.sh
@@ -5,12 +5,17 @@ step_setup() {
   ensure_clean_main
 
   ISSUES_FILE="/tmp/claude/agent-issues.json"
+  local RAW_ISSUES_FILE="/tmp/claude/agent-issues-raw.json"
   mkdir -p /tmp/claude
-  if gh issue list --label "$AGENT_LABEL" --state open --json number,title,body,labels \
-       --limit 50 > "$ISSUES_FILE" 2>/dev/null; then
-    local issue_count
+  if gh issue list --label "$AGENT_LABEL" --state open --json number,title,body,labels,author \
+       --limit 50 > "$RAW_ISSUES_FILE" 2>/dev/null; then
+    # Filter issues to only include those from the allowed author
+    jq --arg author "$ALLOWED_ISSUE_AUTHOR" \
+      '[.[] | select(.author.login == $author)]' "$RAW_ISSUES_FILE" > "$ISSUES_FILE"
+    local issue_count raw_count
+    raw_count=$(jq length "$RAW_ISSUES_FILE")
     issue_count=$(jq length "$ISSUES_FILE")
-    log "Fetched $issue_count open issues with label '$AGENT_LABEL'"
+    log "Fetched $raw_count open issues with label '$AGENT_LABEL' ($issue_count from allowed author '$ALLOWED_ISSUE_AUTHOR')"
   else
     log "ERROR: Failed to fetch GitHub issues. Cannot proceed without issue source."
     sleep "$SLEEP_SECONDS"


### PR DESCRIPTION
## Summary

Implements issue #150: issueを保護しrepoを公開できるようにする

## 概要

リポジトリを public にするにあたり、外部からの不正な Issue 作成を防ぐ仕組みを導入する。

## やること

### 1. Issue 作成者の制限
- Issue が作成された時に、作成者が `xiangma9712` でなければ自動的にクローズするワークフローを追加する
- クローズ時にコメントで理由を通知する
- またAgent loopの中でauthorが`xiangma9712`でなければ処理対象としない

### 2. blank issue の無効化
- `.github/ISSUE_TEMPLATE/config.yml` の `blank_issues_enabled` を `false` に変更する

## 対象ファイル
- `.github/workflows/` に新しいワークフローを追加
- `.github/ISSUE_TEMPLATE/config.yml` を修正

Closes #150

---
Generated by agent/loop.sh