### PR TITLE
feat: feat: Anthropic Messages API互換HTTPクライアントの実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -4007,7 +4008,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ keyring = { version = "3", features = ["apple-native"] }
 
 [dev-dependencies]
 tempfile = "3.25.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/lib/llm/client.rs
+++ b/lib/llm/client.rs
@@ -1,53 +1,69 @@
-use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
-/// LLMクライアント
+use anyhow::{Context, Result};
+
+use super::types::{LlmRequest, LlmResponse, Message};
+
+const DEFAULT_API_BASE: &str = "https://api.anthropic.com";
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Anthropic Messages API互換 LLMクライアント
 ///
-/// OpenAI互換APIを呼び出す最小限のクライアント。
-/// `api_base` を変更することでOpenAI, Anthropic (proxy) 等に対応可能。
+/// `api_base` を変更することでローカルLLM等にも対応可能。
+/// `api_key` は `Option` とし、ローカルLLMの場合は省略できる。
 pub struct LlmClient {
-    api_key: String,
+    api_key: Option<String>,
     api_base: String,
     model: String,
+    http: reqwest::Client,
 }
 
 impl LlmClient {
-    /// OpenAI APIをデフォルトで使用するクライアントを作成する
-    pub fn new(api_key: String, model: String) -> Self {
+    /// デフォルトのAnthropic APIを使用するクライアントを作成する
+    pub fn new(api_key: Option<String>, model: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("HTTPクライアントの初期化に失敗");
         Self {
             api_key,
-            api_base: "https://api.openai.com/v1".to_string(),
+            api_base: DEFAULT_API_BASE.to_string(),
             model,
+            http,
         }
     }
 
     /// カスタムAPIベースURLを指定してクライアントを作成する
-    pub fn with_api_base(api_key: String, api_base: String, model: String) -> Self {
+    pub fn with_api_base(api_key: Option<String>, api_base: String, model: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("HTTPクライアントの初期化に失敗");
         Self {
             api_key,
             api_base,
             model,
+            http,
         }
     }
 
-    /// テキストプロンプトを送信して応答を取得する
-    pub async fn chat(&self, prompt: &str) -> Result<String> {
-        let client = reqwest::Client::new();
-        let url = format!("{}/chat/completions", self.api_base);
+    /// Anthropic Messages APIにリクエストを送信し、レスポンスを取得する
+    pub async fn send(&self, request: &LlmRequest) -> Result<LlmResponse> {
+        let url = format!("{}/v1/messages", self.api_base);
 
-        let request = ChatRequest {
-            model: self.model.clone(),
-            messages: vec![ChatMessage {
-                role: "user".to_string(),
-                content: prompt.to_string(),
-            }],
-        };
-
-        let response = client
+        let mut builder = self
+            .http
             .post(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
-            .json(&request)
+            .header("content-type", "application/json")
+            .header("anthropic-version", ANTHROPIC_VERSION);
+
+        if let Some(ref key) = self.api_key {
+            builder = builder.header("x-api-key", key);
+        }
+
+        let response = builder
+            .json(request)
             .send()
             .await
             .context("LLM APIリクエストの送信に失敗しました")?;
@@ -58,88 +74,201 @@ impl LlmClient {
             anyhow::bail!("LLM API returned {status}: {body}");
         }
 
-        let chat_response: ChatResponse = response
+        let llm_response: LlmResponse = response
             .json()
             .await
             .context("LLM APIレスポンスのパースに失敗しました")?;
 
-        chat_response
-            .choices
+        Ok(llm_response)
+    }
+
+    /// テキストプロンプトを送信して応答テキストを取得する（簡易メソッド）
+    ///
+    /// 内部で `send()` を呼び出し、最初のテキストブロックの内容を返す。
+    pub async fn chat(&self, prompt: &str) -> Result<String> {
+        let request = LlmRequest {
+            model: self.model.clone(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+            }],
+            max_tokens: 4096,
+            system: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+        };
+
+        let response = self.send(&request).await?;
+
+        response
+            .content
             .into_iter()
-            .next()
-            .map(|c| c.message.content)
+            .find(|block| block.block_type == "text")
+            .map(|block| block.text)
             .context("LLM APIからの応答が空です")
     }
-}
-
-#[derive(Serialize)]
-struct ChatRequest {
-    model: String,
-    messages: Vec<ChatMessage>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct ChatMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct ChatResponse {
-    choices: Vec<ChatChoice>,
-}
-
-#[derive(Deserialize)]
-struct ChatChoice {
-    message: ChatMessage,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::types::{ContentBlock, LlmResponse, Usage};
 
     #[test]
     fn test_llm_client_new() {
-        let client = LlmClient::new("test-key".to_string(), "gpt-4".to_string());
-        assert_eq!(client.api_key, "test-key");
-        assert_eq!(client.api_base, "https://api.openai.com/v1");
-        assert_eq!(client.model, "gpt-4");
+        let client = LlmClient::new(
+            Some("test-key".to_string()),
+            "claude-sonnet-4-5-20250929".to_string(),
+        );
+        assert_eq!(client.api_key, Some("test-key".to_string()));
+        assert_eq!(client.api_base, "https://api.anthropic.com");
+        assert_eq!(client.model, "claude-sonnet-4-5-20250929");
+    }
+
+    #[test]
+    fn test_llm_client_new_without_api_key() {
+        let client = LlmClient::new(None, "local-model".to_string());
+        assert_eq!(client.api_key, None);
+        assert_eq!(client.api_base, "https://api.anthropic.com");
+        assert_eq!(client.model, "local-model");
     }
 
     #[test]
     fn test_llm_client_with_api_base() {
         let client = LlmClient::with_api_base(
-            "key".to_string(),
-            "https://custom.api.com/v1".to_string(),
-            "model".to_string(),
+            None,
+            "http://localhost:11434".to_string(),
+            "llama3".to_string(),
         );
-        assert_eq!(client.api_base, "https://custom.api.com/v1");
+        assert_eq!(client.api_key, None);
+        assert_eq!(client.api_base, "http://localhost:11434");
+        assert_eq!(client.model, "llama3");
     }
 
     #[test]
-    fn test_chat_request_serializes() {
-        let request = ChatRequest {
-            model: "gpt-4".to_string(),
-            messages: vec![ChatMessage {
+    fn test_chat_builds_correct_request() {
+        // chat()が構築するLlmRequestの構造を検証
+        let request = LlmRequest {
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            messages: vec![Message {
                 role: "user".to_string(),
                 content: "hello".to_string(),
             }],
+            max_tokens: 4096,
+            system: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
         };
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["model"], "gpt-4");
+        assert_eq!(json["model"], "claude-sonnet-4-5-20250929");
         assert_eq!(json["messages"][0]["role"], "user");
         assert_eq!(json["messages"][0]["content"], "hello");
+        assert_eq!(json["max_tokens"], 4096);
+        // Optionalフィールドは省略される
+        assert!(json.get("system").is_none());
+        assert!(json.get("temperature").is_none());
     }
 
     #[test]
-    fn test_chat_response_deserializes() {
-        let json = r#"{
-            "choices": [{
-                "message": { "role": "assistant", "content": "response text" }
-            }]
-        }"#;
-        let response: ChatResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.choices.len(), 1);
-        assert_eq!(response.choices[0].message.content, "response text");
+    fn test_llm_response_text_extraction() {
+        // send()のレスポンスからテキストを抽出するロジックを検証
+        let response = LlmResponse {
+            id: "msg_test".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![ContentBlock {
+                block_type: "text".to_string(),
+                text: "response text".to_string(),
+            }],
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 20,
+            },
+        };
+
+        let text = response
+            .content
+            .into_iter()
+            .find(|block| block.block_type == "text")
+            .map(|block| block.text);
+
+        assert_eq!(text, Some("response text".to_string()));
+    }
+
+    #[test]
+    fn test_llm_response_empty_content_returns_none() {
+        let response = LlmResponse {
+            id: "msg_empty".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![],
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 0,
+            },
+        };
+
+        let text = response
+            .content
+            .into_iter()
+            .find(|block| block.block_type == "text")
+            .map(|block| block.text);
+
+        assert!(text.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_send_connection_refused_returns_error() {
+        let client = LlmClient::with_api_base(
+            None,
+            "http://127.0.0.1:1".to_string(),
+            "test-model".to_string(),
+        );
+        let request = LlmRequest {
+            model: "test-model".to_string(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+            }],
+            max_tokens: 100,
+            system: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+        };
+
+        let result = client.send(&request).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("LLM APIリクエストの送信に失敗しました"));
+    }
+
+    #[tokio::test]
+    async fn test_chat_connection_refused_returns_error() {
+        let client = LlmClient::with_api_base(
+            None,
+            "http://127.0.0.1:1".to_string(),
+            "test-model".to_string(),
+        );
+
+        let result = client.chat("hello").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("LLM APIリクエストの送信に失敗しました"));
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #167: feat: Anthropic Messages API互換HTTPクライアントの実装

## 概要

`lib/llm/client.rs` の既存OpenAI互換クライアントをAnthropic Messages API互換に書き換える。

## 要件

- [ ] `LlmClient` 構造体を再実装する
  - `api_key: Option<String>`（ローカルLLM対応のためOptionにする）
  - `api_base: String`（デフォルト: `https://api.anthropic.com`）
  - `model: String`
  - 内部に `reqwest::Client` を保持（接続の再利用）
- [ ] `async fn send(&self, request: &LlmRequest) -> Result<LlmResponse>` を実装
  - エンドポイント: `POST {api_base}/v1/messages`
  - ヘッダー: `x-api-key`, `anthropic-version: 2023-06-01`, `content-type: application/json`
  - APIキーが無い場合は `x-api-key` ヘッダーを省略する
- [ ] 既存の `chat()` メソッドのシグネチャを維持するか、呼び出し元（`summary.rs`, `app/src/main.rs`）を更新する
- [ ] タイムアウト設定（デフォルト30秒）
- [ ] 型レベルのテスト + エラーハンドリングのテスト
- [ ] `cargo build` / `cargo test` / `cargo clippy --all-targets -- -D warnings` が通ること

## 技術メモ

- 前提: types.rs の型定義（前のsub-issue）が完了していること
- `reqwest::Client` はコンストラクタで1回だけ作成し、フィールドに保持するのがベストプラクティス
- 既存の `summary.rs` と `app/src/main.rs` の呼び出し箇所もこのIssueで更新する

Parent: #159

Closes #167

---
Generated by agent/loop.sh