### PR TITLE
fix: UI: トーン&マナーの刷新（白背景 + グレーサイドメニュー）

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja" class="dark">
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/frontend/src/components/BranchTab.tsx
+++ b/frontend/src/components/BranchTab.tsx
@@ -137,7 +137,7 @@ export function BranchTab({ showConfirm, prs }: Props) {
   return (
     <div>
       <Card className="flex flex-col">
-        <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+        <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
           {t("branch.title")}
         </h2>
         <div className="scrollbar-custom mb-4 min-h-[120px] max-h-[360px] flex-1 overflow-y-auto">

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -11,7 +11,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<Variant, string> = {
   primary:
-    "bg-accent text-bg-primary font-semibold hover:bg-accent-hover",
+    "bg-accent text-white font-semibold hover:bg-accent-hover",
   secondary:
     "bg-btn-secondary text-text-primary hover:bg-btn-secondary-hover",
   destructive:

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -25,7 +25,7 @@ export function ConfirmDialog({
     <Dialog.Root open={open} onOpenChange={(v) => !v && onCancel()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[90%] max-w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-bg-secondary p-6 focus:outline-none">
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[90%] max-w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-bg-primary p-6 shadow-lg focus:outline-none">
           <Dialog.Title className="sr-only">
             {t("common.confirm")}
           </Dialog.Title>

--- a/frontend/src/components/DiffTab.tsx
+++ b/frontend/src/components/DiffTab.tsx
@@ -79,7 +79,7 @@ export function DiffTab() {
     <div>
       <div className="grid min-h-[500px] grid-cols-[280px_1fr] gap-4">
         <Card className="flex flex-col">
-          <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+          <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
             {t("diff.changedFiles")}
           </h2>
           <div className="scrollbar-custom flex-1 overflow-y-auto">
@@ -126,7 +126,7 @@ export function DiffTab() {
           </div>
         </Card>
         <Card className="flex flex-col overflow-hidden">
-          <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+          <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
             {selectedDiff
               ? (selectedDiff.new_path ?? selectedDiff.old_path ?? "Diff")
               : "Diff"}

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -20,7 +20,7 @@ export function Dropdown({ trigger, items, align = "end" }: DropdownProps) {
 
       <DropdownMenu.Portal>
         <DropdownMenu.Content
-          className="z-50 min-w-[140px] rounded-lg border border-border bg-bg-secondary p-1 shadow-lg"
+          className="z-50 min-w-[140px] rounded-lg border border-border bg-bg-primary p-1 shadow-lg"
           sideOffset={4}
           align={align}
         >

--- a/frontend/src/components/PrTab.tsx
+++ b/frontend/src/components/PrTab.tsx
@@ -184,7 +184,7 @@ export function PrTab({ prs, setPrs }: PrTabProps) {
         </div>
         <div className="grid min-h-[500px] grid-cols-[280px_1fr] gap-4">
           <Card className="flex flex-col">
-            <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+            <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
               {t("diff.changedFiles")}
             </h2>
             <div className="scrollbar-custom flex-1 overflow-y-auto">
@@ -223,7 +223,7 @@ export function PrTab({ prs, setPrs }: PrTabProps) {
             </div>
           </Card>
           <Card className="flex flex-col overflow-hidden">
-            <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+            <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
               {selectedDiff
                 ? (selectedDiff.new_path ?? selectedDiff.old_path ?? "Diff")
                 : "Diff"}
@@ -295,7 +295,7 @@ export function PrTab({ prs, setPrs }: PrTabProps) {
   return (
     <div>
       <section className="flex flex-col rounded-lg border border-border bg-bg-secondary p-5">
-        <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+        <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
           {t("pr.title")}
         </h2>
         <div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -19,9 +19,9 @@ export function Sidebar({
   const { t } = useTranslation();
 
   return (
-    <aside className="flex h-full w-56 flex-col border-r border-border bg-bg-secondary">
+    <aside className="flex h-full w-56 flex-col border-r border-border bg-sidebar-bg">
       <div className="flex items-center gap-2 border-b border-border px-4 py-3">
-        <h1 className="text-lg font-bold text-white">{t("app.title")}</h1>
+        <h1 className="text-lg font-bold text-text-heading">{t("app.title")}</h1>
       </div>
       <div className="border-b border-border px-4 py-2">
         <span className="text-[0.7rem] font-semibold uppercase tracking-wider text-text-muted">

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -16,7 +16,7 @@ export function TabBar({ items, activeId, onSelect }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="flex border-b border-border bg-bg-secondary">
+    <div className="flex border-b border-border bg-bg-primary">
       {items.map((item) => (
         <button
           key={item.id}

--- a/frontend/src/components/WorktreeTab.tsx
+++ b/frontend/src/components/WorktreeTab.tsx
@@ -72,7 +72,7 @@ export function WorktreeTab() {
   return (
     <div>
       <Card className="flex flex-col">
-        <h2 className="mb-4 border-b border-border pb-2 text-lg text-white">
+        <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
           {t("worktree.title")}
         </h2>
         <div className="scrollbar-custom mb-4 min-h-[120px] max-h-[360px] flex-1 overflow-y-auto">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,32 +1,34 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg-primary: #1a1a2e;
-  --color-bg-secondary: #16213e;
-  --color-bg-hover: #1a2a3e;
-  --color-border: #2a2a3e;
-  --color-border-hover: #3a3a5e;
-  --color-text-primary: #e0e0e0;
-  --color-text-secondary: #a0a0b0;
-  --color-text-muted: #5a5a7e;
-  --color-accent: #4ec9b0;
-  --color-accent-hover: #3db89f;
-  --color-danger: #e06c75;
-  --color-danger-hover: #c85a63;
-  --color-warning: #e5c07b;
-  --color-info: #61afef;
-  --color-purple: #c678dd;
-  --color-btn-secondary: #3a3a5e;
-  --color-btn-secondary-hover: #4a4a6e;
-  --color-bg-hint: #2a2a3e;
-  --color-diff-add-bg: rgba(78, 201, 176, 0.1);
-  --color-diff-del-bg: rgba(224, 108, 117, 0.1);
-  --color-diff-header-bg: #1a1a3e;
-  --color-status-added-bg: #2a4a2a;
-  --color-status-deleted-bg: #4a2a2a;
-  --color-status-modified-bg: #3a3a2a;
-  --color-status-renamed-bg: #2a2a4a;
-  --color-pr-merged-bg: #3a2a4a;
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f3f4f6;
+  --color-bg-hover: #e5e7eb;
+  --color-border: #e5e7eb;
+  --color-border-hover: #d1d5db;
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #6b7280;
+  --color-text-muted: #9ca3af;
+  --color-text-heading: #111827;
+  --color-accent: #0d9488;
+  --color-accent-hover: #0f766e;
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
+  --color-warning: #d97706;
+  --color-info: #2563eb;
+  --color-purple: #9333ea;
+  --color-btn-secondary: #e5e7eb;
+  --color-btn-secondary-hover: #d1d5db;
+  --color-bg-hint: #f3f4f6;
+  --color-diff-add-bg: rgba(22, 163, 74, 0.08);
+  --color-diff-del-bg: rgba(220, 38, 38, 0.08);
+  --color-diff-header-bg: #f0f4ff;
+  --color-status-added-bg: #dcfce7;
+  --color-status-deleted-bg: #fee2e2;
+  --color-status-modified-bg: #fef3c7;
+  --color-status-renamed-bg: #dbeafe;
+  --color-pr-merged-bg: #f3e8ff;
+  --color-sidebar-bg: #f9fafb;
   --font-family-mono: "SF Mono", "Fira Code", monospace;
 }
 
@@ -66,6 +68,10 @@ body {
 .scrollbar-custom::-webkit-scrollbar-thumb {
   background-color: var(--color-border-hover);
   border-radius: 3px;
+}
+
+.scrollbar-custom::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-text-muted);
 }
 
 /* ── Diff line backgrounds (need rgba, not in theme tokens) ──── */


### PR DESCRIPTION
## Summary

Implements issue #134: UI: トーン&マナーの刷新（白背景 + グレーサイドメニュー）

## 概要

現在のUIのトーン&マナーを変更したい。

## 要件

- 白背景ベースのデザインに変更
- グレーのサイドメニューを導入
- 全体的に統一感のあるカラースキームにする

## 関連

- サイドメニューの構成は repo 選択機能（別issue）と連動する

Closes #134

---
Generated by agent/loop.sh