### PR TITLE
feat: PRの変更カテゴリに基づくフォーカスdiff表示機能を追加する

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -122,7 +122,11 @@
     "confirmRequestChanges": "Are you sure you want to request changes on this PR?",
     "reviewSubmitting": "Submitting review…",
     "reviewSuccess": "Review submitted successfully",
-    "reviewError": "Failed to submit review"
+    "reviewError": "Failed to submit review",
+    "focusFilter": "Focus Filter",
+    "focusFilterActive": "Filtered: {{current}}/{{total}} files",
+    "focusFilterReset": "Show All",
+    "focusModuleFilter": "Module"
   },
   "llmSettings": {
     "title": "LLM Settings",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -122,7 +122,11 @@
     "confirmRequestChanges": "このPRにRequest Changesを送信しますか？",
     "reviewSubmitting": "レビューを送信中…",
     "reviewSuccess": "レビューを送信しました",
-    "reviewError": "レビューの送信に失敗しました"
+    "reviewError": "レビューの送信に失敗しました",
+    "focusFilter": "フォーカスフィルタ",
+    "focusFilterActive": "フィルタ中: {{current}}/{{total}} ファイル",
+    "focusFilterReset": "すべて表示",
+    "focusModuleFilter": "モジュール"
   },
   "llmSettings": {
     "title": "LLM設定",


### PR DESCRIPTION
## Summary

Implements issue #202: PRの変更カテゴリに基づくフォーカスdiff表示機能を追加する

## 概要

INTENT.mdの「変更内容について詳しくみたい時だけ、その変更内容に関連するファイル差分だけが見れる」を実現する。

現在PRタブではカテゴリ別にファイルをグルーピングしているが、全ファイルが常に表示されている。特定のカテゴリやモジュールを選択して、関連するファイルだけをフィルタ表示する「フォーカスモード」を追加する。

## 実装内容

1. フロントエンドのPRタブにカテゴリフィルタUIを追加
   - カテゴリバッジ（Logic, Refactor, Test, Config等）をクリックでトグルフィルタ
   - 影響モジュール（LLM分析結果）でのフィルタも追加
2. フィルタ状態に応じてファイル一覧を絞り込み表示
3. 「全て表示」ボタンでフィルタをリセット
4. フィルタ中はヘッダーに選択中のフィルタ条件を表示

## Acceptance Criteria

- [ ] カテゴリバッジクリックでそのカテゴリのファイルのみが表示される
- [ ] 複数カテゴリを選択した場合はOR条件で表示される
- [ ] 影響モジュール名でのフィルタリングができる
- [ ] フィルタリセットで全ファイル表示に戻る
- [ ] フィルタ中にファイル数（n/total）が表示される

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #202

---
Generated by agent/loop.sh