### PR TITLE
feat: GitHub APIからPRのコミット一覧を取得する関数を追加する

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -84,6 +84,18 @@ async fn get_pull_request_files(
 }
 
 #[tauri::command]
+async fn list_pr_commits(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    token: String,
+) -> Result<Vec<reown::github::CommitInfo>, AppError> {
+    reown::github::pull_request::list_pr_commits(&owner, &repo, pr_number, &token)
+        .await
+        .map_err(AppError::github)
+}
+
+#[tauri::command]
 async fn submit_pr_review(
     owner: String,
     repo: String,
@@ -440,6 +452,7 @@ fn main() {
             diff_commit,
             list_pull_requests,
             get_pull_request_files,
+            list_pr_commits,
             submit_pr_review,
             analyze_pr_risk,
             analyze_pr_risk_with_llm,

--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -1,5 +1,5 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
-import type { WorktreeInfo, BranchInfo, FileDiff, CategorizedFileDiff, PrInfo, RepositoryEntry, AppConfig, LlmConfig, AutomationConfig, RepoInfo, PrSummary, ConsistencyResult, AnalysisResult, HybridAnalysisResult, ReviewEvent, TodoItem } from "./types";
+import type { WorktreeInfo, BranchInfo, FileDiff, CategorizedFileDiff, PrInfo, CommitInfo, RepositoryEntry, AppConfig, LlmConfig, AutomationConfig, RepoInfo, PrSummary, ConsistencyResult, AnalysisResult, HybridAnalysisResult, ReviewEvent, TodoItem } from "./types";
 
 type Commands = {
   list_worktrees: { args: { repoPath: string }; ret: WorktreeInfo[] };
@@ -20,6 +20,10 @@ type Commands = {
   get_pull_request_files: {
     args: { owner: string; repo: string; prNumber: number; token: string };
     ret: CategorizedFileDiff[];
+  };
+  list_pr_commits: {
+    args: { owner: string; repo: string; prNumber: number; token: string };
+    ret: CommitInfo[];
   };
   submit_pr_review: {
     args: { owner: string; repo: string; prNumber: number; event: ReviewEvent; body: string; token: string };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -50,6 +50,14 @@ export interface PrInfo {
   html_url: string;
 }
 
+export interface CommitInfo {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+  commit_url: string;
+}
+
 export interface RepositoryEntry {
   name: string;
   path: string;

--- a/lib/github/mod.rs
+++ b/lib/github/mod.rs
@@ -3,8 +3,10 @@ pub mod pull_request;
 #[allow(dead_code)]
 pub mod types;
 
+pub use pull_request::CommitInfo;
 pub use pull_request::PrInfo;
 pub use pull_request::ReviewEvent;
 pub use pull_request::get_pull_request_files;
+pub use pull_request::list_pr_commits;
 #[allow(unused_imports)]
 pub use types::PullRequest;


### PR DESCRIPTION
## Summary

Implements issue #212: GitHub APIからPRのコミット一覧を取得する関数を追加する

## 概要

`lib/github/pull_request.rs` に `list_pr_commits()` 関数を追加し、GitHub APIからPRのコミット一覧を取得できるようにする。`diff_commit` Tauriコマンドは既に実装済みのため、コミット一覧の取得がフロントエンド実装のブロッカーとなっている。

## 実装内容

- `CommitInfo` 型を `lib/github/pull_request.rs` に追加する（sha, message, author, date, commit_url）
- `list_pr_commits(owner, repo, pr_number, token)` 関数を実装する（`GET /repos/{owner}/{repo}/pulls/{number}/commits`）
- 既存の `list_pull_requests()` と同様のパターン（reqwest, ヘッダー, ページネーション, エラーハンドリング）に従う
- `lib/github/mod.rs` から `CommitInfo` と `list_pr_commits` を re-export する
- `app/src/main.rs` に `list_pr_commits` Tauriコマンドを追加し、`tauri::generate_handler![]` に登録する
- `frontend/src/types.ts` に `CommitInfo` 型を追加する
- `frontend/src/invoke.ts` に `list_pr_commits` コマンド定義を追加する
- GitHub APIレスポンスのパースに関するユニットテストを追加する

## Acceptance Criteria

- [ ] `CommitInfo` 型が定義されている
- [ ] `list_pr_commits()` がGitHub APIからコミット一覧を取得できる
- [ ] Tauriコマンド `list_pr_commits` が登録されている
- [ ] フロントエンドの型定義（`CommitInfo`）と invoke ラッパーが追加されている
- [ ] テストが追加されている

Parent: #208

Closes #212

---
Generated by agent/loop.sh