### PR TITLE
feat: GitHub GraphQL API で enablePullRequestAutoMerge mutation を実装する

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -111,6 +111,21 @@ async fn submit_pr_review(
     .map_err(AppError::github)
 }
 
+#[tauri::command]
+async fn enable_pr_auto_merge(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    merge_method: reown::github::MergeMethod,
+    token: String,
+) -> Result<(), AppError> {
+    reown::github::pull_request::enable_auto_merge(
+        &token, &owner, &repo, pr_number, merge_method,
+    )
+    .await
+    .map_err(AppError::github)
+}
+
 // ── Git info commands ──────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -454,6 +469,7 @@ fn main() {
             get_pull_request_files,
             list_pr_commits,
             submit_pr_review,
+            enable_pr_auto_merge,
             analyze_pr_risk,
             analyze_pr_risk_with_llm,
             summarize_pull_request,

--- a/lib/github/mod.rs
+++ b/lib/github/mod.rs
@@ -4,6 +4,7 @@ pub mod pull_request;
 pub mod types;
 
 pub use pull_request::CommitInfo;
+pub use pull_request::MergeMethod;
 pub use pull_request::PrInfo;
 pub use pull_request::ReviewEvent;
 pub use pull_request::get_pull_request_files;


### PR DESCRIPTION
## Summary

Implements issue #215: GitHub GraphQL API で enablePullRequestAutoMerge mutation を実装する

## 概要

GitHub の `enablePullRequestAutoMerge` は GraphQL API でのみ提供されている。現在 `lib/github/pull_request.rs` は REST API のみ使用しているため、GraphQL mutation を呼び出す関数を追加する。

## 実装内容

1. `lib/github/pull_request.rs` に `enable_auto_merge(token, owner, repo, pr_number, merge_method)` 関数を追加
2. GitHub GraphQL エンドポイント (`https://api.github.com/graphql`) への POST リクエストを実装
3. PR番号からNode IDを取得し、`enablePullRequestAutoMerge` mutation を実行する
4. `app/src/main.rs` に `enable_pr_auto_merge` Tauriコマンドを追加し `generate_handler!` に登録
5. ユニットテスト（リクエストボディの構築テスト等）を追加

## Acceptance Criteria

- [ ] `enable_auto_merge()` 関数が `lib/github/pull_request.rs` に実装されている
- [ ] GraphQL mutation のリクエストボディが正しく構築される
- [ ] merge method (MERGE, SQUASH, REBASE) を指定できる
- [ ] Tauriコマンド `enable_pr_auto_merge` が追加されている
- [ ] テストが追加されている
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #207

Closes #215

---
Generated by agent/loop.sh