### PR TITLE
feat: レビューパターンサジェストのTauriコマンド追加

### DIFF
--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -1,5 +1,5 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
-import type { WorktreeInfo, BranchInfo, FileDiff, CategorizedFileDiff, PrInfo, CommitInfo, RepositoryEntry, AppConfig, LlmConfig, AutomationConfig, RepoInfo, PrSummary, ConsistencyResult, AnalysisResult, HybridAnalysisResult, ReviewEvent, TodoItem } from "./types";
+import type { WorktreeInfo, BranchInfo, FileDiff, CategorizedFileDiff, PrInfo, CommitInfo, RepositoryEntry, AppConfig, LlmConfig, AutomationConfig, RepoInfo, PrSummary, ConsistencyResult, AnalysisResult, HybridAnalysisResult, ReviewEvent, TodoItem, ReviewSuggestion } from "./types";
 
 type Commands = {
   list_worktrees: { args: { repoPath: string }; ret: WorktreeInfo[] };
@@ -83,6 +83,10 @@ type Commands = {
   };
   load_automation_config: { args?: Record<string, unknown>; ret: AutomationConfig };
   extract_todos: { args: { repoPath: string }; ret: TodoItem[] };
+  suggest_review_comments: {
+    args: { owner: string; repo: string; prNumber: number; token: string };
+    ret: ReviewSuggestion[];
+  };
 };
 
 export async function invoke<C extends keyof Commands>(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -206,3 +206,39 @@ export interface HybridAnalysisResult {
   llm_analysis: LlmAnalysisResult;
   combined_risk_level: RiskLevel;
 }
+
+// ── Review Pattern Types ────────────────────────────────────────────────────
+
+export interface CategoryStat {
+  total: number;
+  approved: number;
+  rejected: number;
+  reject_rate: number;
+}
+
+export interface RiskStat {
+  total: number;
+  approved: number;
+  rejected: number;
+  reject_rate: number;
+}
+
+export interface RejectPathPattern {
+  pattern: string;
+  reject_count: number;
+}
+
+export interface ReviewPatternStats {
+  category_stats: Record<ChangeCategory, CategoryStat>;
+  risk_stats: Record<RiskLevel, RiskStat>;
+  reject_path_patterns: RejectPathPattern[];
+  total_reviews: number;
+}
+
+export type SuggestionSeverity = "Info" | "Warning" | "Alert";
+
+export interface ReviewSuggestion {
+  message: string;
+  severity: SuggestionSeverity;
+  source: string;
+}


### PR DESCRIPTION
## Summary

Implements issue #220: レビューパターンサジェストのTauriコマンド追加

## 概要

#201 のバックエンドロジック（`analyze_review_patterns` / `suggest_review_focus`）をフロントエンドから呼び出すためのTauriコマンドを追加する。

## 前提

レビューパターン分析ロジック（`lib/analysis/review_pattern.rs`）が実装済みであること。

## 実装内容

1. `app/src/main.rs` に以下のTauriコマンドを追加:
   - `suggest_review_comments(app_handle, owner, repo, pr_number, token)` → `Vec<ReviewSuggestion>`
     - 内部で `list_review_history` → `analyze_review_patterns` → PRのファイル情報取得 → `suggest_review_focus` を実行
2. `tauri::generate_handler![]` にコマンドを登録
3. `frontend/src/types.ts` に `ReviewPatternStats`, `ReviewSuggestion`, `SuggestionSeverity` の型定義を追加
4. `frontend/src/invoke.ts` にIPC呼び出しラッパーを追加（任意）

## Acceptance Criteria

- [ ] `suggest_review_comments` Tauriコマンドが登録されている
- [ ] フロントエンドからinvoke経由で呼び出し可能
- [ ] TypeScript型定義が追加されている
- [ ] `cargo build` が通る
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #201

Closes #220

---
Generated by agent/loop.sh