### PR TITLE
fix: 全体的なpaddingを調整する

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -8,7 +8,7 @@ interface Props {
 export function Card({ children, className = "" }: Props) {
   return (
     <section
-      className={`rounded-lg border border-border bg-bg-secondary p-5 ${className}`}
+      className={`rounded-lg border border-border bg-bg-secondary p-6 ${className}`}
     >
       {children}
     </section>
@@ -18,7 +18,7 @@ export function Card({ children, className = "" }: Props) {
 export function Panel({ children, className = "" }: Props) {
   return (
     <div
-      className={`rounded-lg border border-border bg-bg-primary p-4 ${className}`}
+      className={`rounded-lg border border-border bg-bg-primary p-5 ${className}`}
     >
       {children}
     </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -51,7 +51,7 @@ export function Layout({
           <>
             <div className="flex items-center border-b border-border bg-bg-primary">
               {branchSelector && (
-                <div className="shrink-0 border-r border-border px-3 py-1.5">
+                <div className="shrink-0 border-r border-border px-4 py-2">
                   {branchSelector}
                 </div>
               )}
@@ -61,7 +61,7 @@ export function Layout({
                 onSelect={onSelectTab}
               />
             </div>
-            <main className="scrollbar-custom flex-1 overflow-y-auto p-6">
+            <main className="scrollbar-custom flex-1 overflow-y-auto p-8">
               {children}
             </main>
           </>

--- a/frontend/src/components/PrTab.tsx
+++ b/frontend/src/components/PrTab.tsx
@@ -731,8 +731,8 @@ export function PrTab({
   // PR diff view
   if (selectedPr) {
     return (
-      <div>
-        <div className="mb-4 flex items-center gap-3">
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
           <Button onClick={handleBackToList}>{t("pr.backToList")}</Button>
           <span className="font-mono text-[0.8rem] font-semibold text-info">
             #{selectedPr.number}
@@ -773,7 +773,7 @@ export function PrTab({
           token={token.trim()}
         />
         {/* Review action section */}
-        <Card className="mt-4">
+        <Card>
           <h2 className="mb-3 border-b border-border pb-2 text-lg text-text-heading">
             Review
           </h2>
@@ -1312,7 +1312,7 @@ export function PrTab({
   // PR list view
   return (
     <div>
-      <section className="flex flex-col rounded-lg border border-border bg-bg-secondary p-5">
+      <section className="flex flex-col rounded-lg border border-border bg-bg-secondary p-6">
         <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
           {t("pr.title")}
         </h2>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar({
           {t("repository.title")}
         </span>
       </div>
-      <nav className="scrollbar-custom flex-1 overflow-y-auto py-1">
+      <nav className="scrollbar-custom flex-1 overflow-y-auto py-2">
         {repositories.length === 0 ? (
           <p className="px-4 py-3 text-sm text-text-muted">
             {t("repository.empty")}
@@ -66,7 +66,7 @@ export function Sidebar({
           ))
         )}
       </nav>
-      <div className="border-t border-border px-3 py-2">
+      <div className="border-t border-border px-4 py-3">
         <button
           onClick={onAdd}
           className="flex w-full cursor-pointer items-center justify-center gap-1 rounded border border-border bg-transparent px-3 py-1.5 text-sm text-text-secondary transition-colors hover:border-accent hover:text-accent"

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -21,7 +21,7 @@ export function TabBar({ items, activeId, onSelect }: Props) {
         <button
           key={item.id}
           onClick={() => onSelect(item.id)}
-          className={`cursor-pointer border-none px-4 py-2 text-base transition-colors ${
+          className={`cursor-pointer border-none px-5 py-2.5 text-base transition-colors ${
             activeId === item.id
               ? "border-b-2 border-b-accent bg-transparent text-accent"
               : "border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"


### PR DESCRIPTION
## Summary

Implements issue #233: 全体的なpaddingを調整する

## 概要

アプリ全体でpaddingが不足しており、UIが窮屈に見える。適切なpaddingを設定して見た目を改善する。

## 実装内容

- 各コンポーネント・セクション間のpaddingを見直し、統一的なスペーシングを適用する
- コンテンツ領域の左右・上下のpaddingを適切に設定する

## Acceptance Criteria

- [ ] 各コンポーネントに適切なpaddingが設定されている
- [ ] UI全体で統一的なスペーシングになっている
- [ ] コンテンツが窮屈に見えない

Closes #233

---
Generated by agent/loop.sh