### PR TITLE
feat: pre-commit hookを導入する

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# pre-commit hook: lint/format チェック
+# インストール: mise run install-hook
+
+errors=0
+
+# --- フロントエンド: 変更ファイルに対して Prettier + ESLint チェック ---
+frontend_files=$(git diff --cached --name-only --diff-filter=ACM -- 'frontend/src/**/*.ts' 'frontend/src/**/*.tsx' 'frontend/src/**/*.css' 'frontend/src/**/*.html' 'frontend/*.js' 'frontend/*.ts' 'frontend/*.json')
+
+if [ -n "$frontend_files" ]; then
+  echo ">>> フロントエンド: Prettier チェック..."
+  # ステージされたファイルからfrontend/プレフィックスを除去してfrontendディレクトリからの相対パスにする
+  prettier_files=$(echo "$frontend_files" | sed 's|^frontend/||')
+  if ! (cd frontend && echo "$prettier_files" | xargs npx prettier --check) ; then
+    echo "Prettier チェック失敗。'cd frontend && npm run format' を実行してください。"
+    errors=1
+  fi
+
+  echo ">>> フロントエンド: ESLint チェック..."
+  eslint_files=$(echo "$frontend_files" | sed 's|^frontend/||' | grep -E '\.(ts|tsx)$' || true)
+  if [ -n "$eslint_files" ]; then
+    if ! (cd frontend && echo "$eslint_files" | xargs npx eslint) ; then
+      echo "ESLint チェック失敗。'cd frontend && npm run lint' で確認してください。"
+      errors=1
+    fi
+  fi
+fi
+
+# --- Rust: cargo fmt チェック ---
+rust_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.rs')
+
+if [ -n "$rust_files" ]; then
+  echo ">>> Rust: cargo fmt チェック..."
+  if ! cargo fmt --check ; then
+    echo "cargo fmt チェック失敗。'cargo fmt' を実行してください。"
+    errors=1
+  fi
+fi
+
+if [ "$errors" -ne 0 ]; then
+  echo ""
+  echo "pre-commit hook に違反があります。修正してから再度コミットしてください。"
+  exit 1
+fi

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,3 +12,7 @@ run = "bash agent/loop.sh {{arg(name='args', var=true, required=false)}}"
 [tasks.agent-stop]
 description = "Gracefully stop the agent loop"
 run = "touch .agent-stop && echo 'Stop requested. Agent will exit after current step.'"
+
+[tasks.install-hook]
+description = "Install pre-commit hook"
+run = "git config core.hooksPath .githooks && echo 'pre-commit hook を有効化しました。'"

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,19 @@ curl https://mise.run | sh
 
 # Node.js をインストール（.mise.toml の設定に従い自動でバージョンが選択される）
 mise install
+
+# pre-commit hook を有効化
+mise run install-hook
 ```
+
+### Pre-commit Hook
+
+`mise run install-hook` を実行すると、`.githooks/pre-commit` が有効化されます。コミット時に以下のチェックが自動実行されます：
+
+- **フロントエンド**: ステージされた変更ファイルに対して Prettier と ESLint をチェック
+- **Rust**: `cargo fmt --check` でフォーマットをチェック
+
+チェックに違反がある場合、コミットは中断されます。
 
 ## ビルド・テスト
 


### PR DESCRIPTION
## Summary

Implements issue #240: pre-commit hookを導入する

## 概要

開発時にlint/formatの問題を早期発見するため、pre-commit hookを導入する。huskyは使わず、miseのタスクでhookをインストールする方式にする。

## 現状

- pre-commit hook なし
- lint/format のチェックは CI でのみ実施されており、コミット時に問題が検出されない

## 実装内容

1. `.githooks/pre-commit` スクリプトを作成：
   - フロントエンド: 変更ファイルに対して Prettier + ESLint をチェック
   - Rust: `cargo fmt --check` を実行
2. `.mise.toml` に `install-hook` タスクを追加：
   - `git config core.hooksPath .githooks` を実行してhookを有効化
3. セットアップ手順をドキュメントに記載

## Acceptance Criteria

- [ ] `mise run install-hook` で pre-commit hook が有効化される
- [ ] `git commit` 時に pre-commit hook が実行される
- [ ] フロントエンドの変更ファイルに対して Prettier と ESLint がチェックされる
- [ ] Rust の変更ファイルに対して cargo fmt がチェックされる
- [ ] hook に違反がある場合にコミットが中断される

Closes #240

---
Generated by agent/loop.sh