### PR TITLE
feat: Settingsをサイドメニュー下部に移動する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,6 @@ const NAV_ITEMS = [
   { id: "diff", labelKey: "tabs.diff", shortcut: "D" },
   { id: "pr", labelKey: "tabs.prs", shortcut: "P" },
   { id: "todo", labelKey: "tabs.todo", shortcut: "T" },
-  { id: "settings", labelKey: "tabs.settings", shortcut: "S" },
 ] as const;
 
 type TabName = (typeof NAV_ITEMS)[number]["id"];
@@ -36,6 +35,7 @@ export function App() {
   const [prs, setPrs] = useState<PrInfo[]>([]);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
   const [selectedPrNumber, setSelectedPrNumber] = useState<number | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmDialog, setConfirmDialog] = useState<{
     message: string;
     resolve: (value: boolean) => void;
@@ -137,24 +137,30 @@ export function App() {
       switch (e.key) {
         case "w":
           setActiveTab("worktree");
+          setSettingsOpen(false);
           break;
         case "b":
           setActiveTab("branch");
+          setSettingsOpen(false);
           break;
         case "d":
           setActiveTab("diff");
+          setSettingsOpen(false);
           break;
         case "p":
           setActiveTab("pr");
+          setSettingsOpen(false);
           break;
         case "t":
           setActiveTab("todo");
+          setSettingsOpen(false);
           break;
         case "s":
-          setActiveTab("settings");
+          setSettingsOpen((prev) => !prev);
           break;
         case "Tab":
           e.preventDefault();
+          setSettingsOpen(false);
           setActiveTab((prev) => {
             const ids = NAV_ITEMS.map((item) => item.id);
             const idx = ids.indexOf(prev);
@@ -178,7 +184,12 @@ export function App() {
         onRemoveRepo={handleRemoveRepo}
         navItems={[...NAV_ITEMS]}
         activeTabId={activeTab}
-        onSelectTab={(id) => setActiveTab(id as TabName)}
+        onSelectTab={(id) => {
+          setActiveTab(id as TabName);
+          setSettingsOpen(false);
+        }}
+        settingsOpen={settingsOpen}
+        onToggleSettings={() => setSettingsOpen((prev) => !prev)}
         branchSelector={
           <BranchSelector
             prs={prs}
@@ -187,31 +198,34 @@ export function App() {
           />
         }
       >
-        {activeTab === "worktree" && (
-          <WorktreeTab prs={prs} onNavigateToPr={navigateToPr} />
-        )}
-        {activeTab === "branch" && (
-          <BranchTab
-            showConfirm={showConfirm}
-            prs={prs}
-            onNavigateToPr={navigateToPr}
-          />
-        )}
-        {activeTab === "diff" && <DiffTab />}
-        {activeTab === "pr" && (
-          <PrTab
-            prs={prs}
-            setPrs={setPrs}
-            selectedPrNumber={selectedPrNumber}
-            onPrSelected={() => setSelectedPrNumber(null)}
-          />
-        )}
-        {activeTab === "todo" && <TodoTab />}
-        {activeTab === "settings" && (
+        {settingsOpen ? (
           <div className="mx-auto max-w-xl space-y-8">
             <LlmSettingsTab />
             <AutomationSettingsTab />
           </div>
+        ) : (
+          <>
+            {activeTab === "worktree" && (
+              <WorktreeTab prs={prs} onNavigateToPr={navigateToPr} />
+            )}
+            {activeTab === "branch" && (
+              <BranchTab
+                showConfirm={showConfirm}
+                prs={prs}
+                onNavigateToPr={navigateToPr}
+              />
+            )}
+            {activeTab === "diff" && <DiffTab />}
+            {activeTab === "pr" && (
+              <PrTab
+                prs={prs}
+                setPrs={setPrs}
+                selectedPrNumber={selectedPrNumber}
+                onPrSelected={() => setSelectedPrNumber(null)}
+              />
+            )}
+            {activeTab === "todo" && <TodoTab />}
+          </>
         )}
 
         <ConfirmDialog

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -19,6 +19,8 @@ interface Props {
   navItems: NavItem[];
   activeTabId: string;
   onSelectTab: (id: string) => void;
+  settingsOpen?: boolean;
+  onToggleSettings?: () => void;
   branchSelector?: ReactNode;
   children: ReactNode;
 }
@@ -32,6 +34,8 @@ export function Layout({
   navItems,
   activeTabId,
   onSelectTab,
+  settingsOpen,
+  onToggleSettings,
   branchSelector,
   children,
 }: Props) {
@@ -45,6 +49,8 @@ export function Layout({
         onSelect={onSelectRepo}
         onAdd={onAddRepo}
         onRemove={onRemoveRepo}
+        settingsOpen={settingsOpen}
+        onToggleSettings={onToggleSettings}
       />
       <div className="flex flex-1 flex-col overflow-hidden">
         {selectedRepoPath ? (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ interface Props {
   onSelect: (path: string) => void;
   onAdd: () => void;
   onRemove: (path: string) => void;
+  settingsOpen?: boolean;
+  onToggleSettings?: () => void;
 }
 
 export function Sidebar({
@@ -15,6 +17,8 @@ export function Sidebar({
   onSelect,
   onAdd,
   onRemove,
+  settingsOpen,
+  onToggleSettings,
 }: Props) {
   const { t } = useTranslation();
 
@@ -72,6 +76,36 @@ export function Sidebar({
           className="flex w-full cursor-pointer items-center justify-center gap-1 rounded border border-border bg-transparent px-3 py-1.5 text-sm text-text-secondary transition-colors hover:border-accent hover:text-accent"
         >
           + {t("repository.add")}
+        </button>
+      </div>
+      <div className="border-t border-border px-4 py-3">
+        <button
+          onClick={onToggleSettings}
+          className={`flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-2 py-1.5 text-sm transition-colors ${
+            settingsOpen
+              ? "text-accent"
+              : "text-text-secondary hover:text-text-primary"
+          }`}
+          title={t("tabs.settings")}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+          {t("tabs.settings")}
+          <kbd className="ml-auto rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted">
+            S
+          </kbd>
         </button>
       </div>
       <div className="border-t border-border px-4 py-3">


### PR DESCRIPTION
## Summary

Implements issue #253: Settingsをサイドメニュー下部に移動する

## 概要

Settingsをタブから除外し、サイドメニュー（Sidebar）の下部に配置する。

## 実装内容

1. `NAV_ITEMS` から `settings` を削除
2. `Sidebar.tsx` の下部に Settings アイコン/リンクを追加
   - 歯車アイコンなどで表示
   - クリックでメインエリアに Settings 画面を表示
3. `App.tsx` で Settings の表示状態を管理
   - Settings が開かれている間はタブコンテンツの代わりに Settings を表示
   - Settings を閉じると元のタブに戻る
4. Settings 画面は既存の `LlmSettingsTab` と `AutomationSettingsTab` をそのまま利用
5. キーボードショートカット S を Settings トグルに変更

## Acceptance Criteria

- [ ] Settings がサイドメニュー下部に配置されている
- [ ] Settings をクリックすると設定画面が表示される
- [ ] 設定画面を閉じると元のタブコンテンツに戻る
- [ ] 既存の LLM 設定・Automation 設定が正常に動作する
- [ ] Settings がタブバーに表示されない
- [ ] `cargo test` と `cargo clippy --all-targets -- -D warnings` が通る

Parent: #234

Closes #253

---
Generated by agent/loop.sh