### PR TITLE
fix: Layout/Sidebar: タブに role="tab" / aria-selected が使われていない

### DIFF
--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -92,4 +92,15 @@ describe("Layout", () => {
     );
     expect(screen.queryByText("Branch Selector")).not.toBeInTheDocument();
   });
+
+  it("renders tabpanel with correct aria attributes", () => {
+    render(
+      <Layout {...defaultProps} activeTabId="review">
+        <div>Content</div>
+      </Layout>
+    );
+    const tabpanel = screen.getByRole("tabpanel");
+    expect(tabpanel).toHaveAttribute("id", "tabpanel-review");
+    expect(tabpanel).toHaveAttribute("aria-labelledby", "tab-review");
+  });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -67,7 +67,12 @@ export function Layout({
                 onSelect={onSelectTab}
               />
             </div>
-            <main className="scrollbar-custom flex-1 overflow-y-auto p-8">
+            <main
+              role="tabpanel"
+              id={`tabpanel-${activeTabId}`}
+              aria-labelledby={`tab-${activeTabId}`}
+              className="scrollbar-custom flex-1 overflow-y-auto p-8"
+            >
               {children}
             </main>
           </>

--- a/frontend/src/components/TabBar.test.tsx
+++ b/frontend/src/components/TabBar.test.tsx
@@ -49,4 +49,27 @@ describe("TabBar", () => {
     await user.click(screen.getByText("Next Action"));
     expect(onSelect).toHaveBeenCalledWith("next-action");
   });
+
+  it("has role=tablist on container and role=tab on buttons", () => {
+    render(<TabBar items={items} activeId="review" onSelect={vi.fn()} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+  });
+
+  it("sets aria-selected on the active tab", () => {
+    render(<TabBar items={items} activeId="review" onSelect={vi.fn()} />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("sets aria-controls and id on each tab", () => {
+    render(<TabBar items={items} activeId="review" onSelect={vi.fn()} />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("id", "tab-review");
+    expect(tabs[0]).toHaveAttribute("aria-controls", "tabpanel-review");
+    expect(tabs[1]).toHaveAttribute("id", "tab-next-action");
+    expect(tabs[1]).toHaveAttribute("aria-controls", "tabpanel-next-action");
+  });
 });

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -16,10 +16,14 @@ export function TabBar({ items, activeId, onSelect }: Props) {
   const { t } = useTranslation();
 
   return (
-    <div className="flex bg-bg-primary">
+    <div role="tablist" className="flex bg-bg-primary">
       {items.map((item) => (
         <button
           key={item.id}
+          role="tab"
+          aria-selected={activeId === item.id}
+          aria-controls={`tabpanel-${item.id}`}
+          id={`tab-${item.id}`}
           onClick={() => onSelect(item.id)}
           className={`cursor-pointer border-none px-5 py-2.5 text-base transition-colors ${
             activeId === item.id


### PR DESCRIPTION
## Summary

Implements issue #342: Layout/Sidebar: タブに role="tab" / aria-selected が使われていない

## 概要

「Review」「Next Action」は視覚的にはタブだが、HTML 上は `<button>` のみ。`role="tablist"` / `role="tab"` / `aria-selected="true"` のセマンティクスがなく、キーボード操作・スクリーンリーダー対応が不十分。

## 対応方針

ARIA Authoring Practices に準拠したタブパターンを実装する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

アクセシビリティ（A11y）

Closes #342

---
Generated by agent/loop.sh