### PR TITLE
fix: Layout/Sidebar: カラーコントラスト不足

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7,8 +7,8 @@
   --color-border: #e5e7eb;
   --color-border-hover: #d1d5db;
   --color-text-primary: #1f2937;
-  --color-text-secondary: #6b7280;
-  --color-text-muted: #9ca3af;
+  --color-text-secondary: #4b5563;
+  --color-text-muted: #6b7280;
   --color-text-heading: #111827;
   --color-accent: #0d9488;
   --color-accent-hover: #0f766e;


### PR DESCRIPTION
## Summary

Implements issue #345: Layout/Sidebar: カラーコントラスト不足

## 概要

以下の要素でカラーコントラストが WCAG 基準（4.5:1）を満たしていない。

- `リポジトリ` ラベル: `rgb(156,163,175)` / 背景 `rgb(249,250,251)` → コントラスト比 約2.8:1
- 非選択リポジトリ名: `rgb(107,114,128)` / 背景 → 約4.0:1
- タグライン p テキスト `rgb(156,163,175)` → 同様に不足

## 対応方針

テキスト色をコントラスト比 4.5:1 以上を満たす値に変更する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

アクセシビリティ（A11y）

Closes #345

---
Generated by agent/loop.sh