### PR TITLE
fix: Layout/Sidebar: フォーカスリング（focus-visible）が確認できない

### DIFF
--- a/frontend/e2e/vrt/layout.spec.ts
+++ b/frontend/e2e/vrt/layout.spec.ts
@@ -27,4 +27,14 @@ test.describe("Layout", () => {
       "with-branch-selector.png"
     );
   });
+
+  test("focus-visible on interactive elements", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-layout--with-repo&viewMode=story"
+    );
+    await page.keyboard.press("Tab");
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "focus-visible.png"
+    );
+  });
 });

--- a/frontend/e2e/vrt/sidebar.spec.ts
+++ b/frontend/e2e/vrt/sidebar.spec.ts
@@ -34,4 +34,14 @@ test.describe("Sidebar", () => {
       "settings-open.png"
     );
   });
+
+  test("focus-visible on interactive elements", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-sidebar--default&viewMode=story"
+    );
+    await page.keyboard.press("Tab");
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "focus-visible.png"
+    );
+  });
 });

--- a/frontend/e2e/vrt/tabbar.spec.ts
+++ b/frontend/e2e/vrt/tabbar.spec.ts
@@ -27,4 +27,14 @@ test.describe("TabBar", () => {
       "third-active.png"
     );
   });
+
+  test("focus-visible on tab", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-tabbar--first-active&viewMode=story"
+    );
+    await page.keyboard.press("Tab");
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "focus-visible.png"
+    );
+  });
 });

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -51,7 +51,7 @@ export function Sidebar({
               }`}
             >
               <button
-                className="flex-1 cursor-pointer truncate border-none bg-transparent text-left text-inherit"
+                className="flex-1 cursor-pointer truncate rounded border-none bg-transparent text-left text-inherit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 onClick={() => onSelect(repo.path)}
                 title={repo.path}
                 aria-label={t("repository.selectAriaLabel", {
@@ -61,7 +61,7 @@ export function Sidebar({
                 {repo.name}
               </button>
               <button
-                className="ml-1 cursor-pointer border-none bg-transparent p-0.5 text-text-muted opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+                className="ml-1 cursor-pointer rounded border-none bg-transparent p-0.5 text-text-muted opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100"
                 onClick={(e) => {
                   e.stopPropagation();
                   onRemove(repo.path);
@@ -80,7 +80,7 @@ export function Sidebar({
       <div className="border-t border-border px-4 py-3">
         <button
           onClick={onAdd}
-          className="flex w-full cursor-pointer items-center justify-center gap-1 rounded border border-border bg-transparent px-3 py-1.5 text-sm text-text-secondary transition-colors hover:border-accent hover:text-accent"
+          className="flex w-full cursor-pointer items-center justify-center gap-1 rounded border border-border bg-transparent px-3 py-1.5 text-sm text-text-secondary transition-colors hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           aria-label={t("repository.addAriaLabel")}
         >
           + {t("repository.add")}
@@ -89,7 +89,7 @@ export function Sidebar({
       <div className="border-t border-border px-4 py-3">
         <button
           onClick={onToggleSettings}
-          className={`flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-2 py-1.5 text-sm transition-colors ${
+          className={`flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-2 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
             settingsOpen
               ? "text-accent"
               : "text-text-secondary hover:text-text-primary"

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -25,7 +25,7 @@ export function TabBar({ items, activeId, onSelect }: Props) {
           aria-controls={`tabpanel-${item.id}`}
           id={`tab-${item.id}`}
           onClick={() => onSelect(item.id)}
-          className={`cursor-pointer border-none px-5 py-2.5 text-base transition-colors ${
+          className={`cursor-pointer border-none px-5 py-2.5 text-base transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
             activeId === item.id
               ? "border-b-2 border-b-accent bg-transparent text-accent"
               : "border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"


### PR DESCRIPTION
## Summary

Implements issue #347: Layout/Sidebar: フォーカスリング（focus-visible）が確認できない

## 概要

ボタン群にフォーカスリングスタイルが設定されておらず、キーボードナビゲーション時に現在地がわからない。

## 対応方針

全インタラクティブ要素に `focus-visible` スタイルを追加する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

アクセシビリティ（A11y）

Closes #347

---
Generated by agent/loop.sh