### PR TITLE
fix: Layout/Sidebar: 削除ボタンがホバー時のみ表示されキーボード・タッチで到達できない

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar({
                 {repo.name}
               </button>
               <button
-                className="ml-1 cursor-pointer rounded border-none bg-transparent p-0.5 text-text-muted opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100"
+                className="ml-1 cursor-pointer rounded border-none bg-transparent p-0.5 text-text-muted opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100 group-focus-within:opacity-100"
                 onClick={(e) => {
                   e.stopPropagation();
                   onRemove(repo.path);


### PR DESCRIPTION
## Summary

Implements issue #351: Layout/Sidebar: 削除ボタンがホバー時のみ表示されキーボード・タッチで到達できない

## 概要

`opacity-0 group-hover:opacity-100` で通常時は非表示。キーボード操作やタッチデバイスではホバーが発生せず、削除操作に到達できない。

## 対応方針

`focus-within` でも表示されるようにするか、常時表示にする。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

インタラクション・操作性

Closes #351

---
Generated by agent/loop.sh