### PR TITLE
fix: Layout/Sidebar: kbd のショートカット表示がアクセシブルでない

### DIFF
--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -130,6 +130,18 @@ describe("Sidebar", () => {
     expect(screen.getByLabelText("設定を開く")).toBeInTheDocument();
   });
 
+  it("has aria-keyshortcuts on settings button", () => {
+    render(<Sidebar {...defaultProps} />);
+    const settingsButton = screen.getByLabelText("設定を開く");
+    expect(settingsButton).toHaveAttribute("aria-keyshortcuts", "S");
+  });
+
+  it("hides kbd shortcut from screen readers", () => {
+    const { container } = render(<Sidebar {...defaultProps} />);
+    const kbd = container.querySelector("kbd");
+    expect(kbd).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("has aria-label on nav element", () => {
     render(<Sidebar {...defaultProps} />);
     expect(

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -104,6 +104,7 @@ export function Sidebar({
           }`}
           title={t("tabs.settings")}
           aria-label={t("tabs.settingsAriaLabel")}
+          aria-keyshortcuts="S"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -120,7 +121,10 @@ export function Sidebar({
             <circle cx="12" cy="12" r="3" />
           </svg>
           {t("tabs.settings")}
-          <kbd className="ml-auto rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted">
+          <kbd
+            aria-hidden="true"
+            className="ml-auto rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted"
+          >
             S
           </kbd>
         </button>

--- a/frontend/src/components/TabBar.test.tsx
+++ b/frontend/src/components/TabBar.test.tsx
@@ -72,4 +72,21 @@ describe("TabBar", () => {
     expect(tabs[1]).toHaveAttribute("id", "tab-next-action");
     expect(tabs[1]).toHaveAttribute("aria-controls", "tabpanel-next-action");
   });
+
+  it("has aria-keyshortcuts on each tab", () => {
+    render(<TabBar items={items} activeId="review" onSelect={vi.fn()} />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-keyshortcuts", "R");
+    expect(tabs[1]).toHaveAttribute("aria-keyshortcuts", "N");
+  });
+
+  it("hides kbd shortcuts from screen readers", () => {
+    const { container } = render(
+      <TabBar items={items} activeId="review" onSelect={vi.fn()} />
+    );
+    const kbds = container.querySelectorAll("kbd");
+    kbds.forEach((kbd) => {
+      expect(kbd).toHaveAttribute("aria-hidden", "true");
+    });
+  });
 });

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -30,9 +30,13 @@ export function TabBar({ items, activeId, onSelect }: Props) {
               ? "border-b-2 border-b-accent bg-transparent text-accent"
               : "border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
           }`}
+          aria-keyshortcuts={item.shortcut}
         >
           <span>{t(item.labelKey)}</span>
-          <kbd className="ml-2 rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted">
+          <kbd
+            aria-hidden="true"
+            className="ml-2 rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted"
+          >
             {item.shortcut}
           </kbd>
         </button>


### PR DESCRIPTION
## Summary

Implements issue #346: Layout/Sidebar: kbd のショートカット表示がアクセシブルでない

## 概要

`<kbd>1</kbd>` はビジュアルのみで、スクリーンリーダーにキーボードショートカットの意味が伝わらない。

## 対応方針

`aria-label` や `aria-keyshortcuts` 属性でキーボードショートカットを明示する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

アクセシビリティ（A11y）

Closes #346

---
Generated by agent/loop.sh