### PR TITLE
fix: Layout/Sidebar: h1 がアプリ名に使われページ見出しと衝突する

### DIFF
--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -48,9 +48,8 @@ describe("Layout", () => {
         <div>Content</div>
       </Layout>
     );
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      "reown"
-    );
+    const allReown = screen.getAllByText("reown");
+    expect(allReown.length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Content")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -39,11 +39,13 @@ const defaultProps = {
 };
 
 describe("Sidebar", () => {
-  it("renders app title", () => {
+  it("renders app title as non-heading element", () => {
     render(<Sidebar {...defaultProps} />);
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      "reown"
-    );
+    expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+    const allReown = screen.getAllByText("reown");
+    expect(allReown.length).toBeGreaterThanOrEqual(1);
+    const brandElement = allReown.find((el) => el.tagName === "SPAN");
+    expect(brandElement).toBeDefined();
   });
 
   it("renders repository list", () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,9 +30,9 @@ export function Sidebar({
   return (
     <aside className="flex h-full w-56 flex-col border-r border-border bg-sidebar-bg">
       <div className="flex items-center gap-2 border-b border-border px-4 py-3">
-        <h1 className="text-xl font-bold text-text-heading">
+        <span className="text-xl font-bold text-text-heading">
           {t("app.title")}
-        </h1>
+        </span>
       </div>
       <div className="border-b border-border px-4 py-2">
         <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">


### PR DESCRIPTION
## Summary

Implements issue #348: Layout/Sidebar: h1 がアプリ名に使われページ見出しと衝突する

## 概要

`reown` という h1 はサイドバーのロゴ・ブランド名であり、ページコンテンツの見出しと混在する。

## 対応方針

`<span>` + ロゴ画像、または `<p>` + `aria-label` に変更し、ページ単位の主見出しと衝突しないようにする。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

構造・セマンティクス

Closes #348

---
Generated by agent/loop.sh