### PR TITLE
feat: CommitListPanel コンポーネントを作成する

### DIFF
--- a/frontend/e2e/vrt/commit-list-panel.spec.ts
+++ b/frontend/e2e/vrt/commit-list-panel.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("CommitListPanel", () => {
+  test("default state", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-commitlistpanel--default&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "default.png"
+    );
+  });
+
+  test("loading state", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-commitlistpanel--loading&viewMode=story"
+    );
+    await page.waitForSelector('[role="status"]', { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "loading.png",
+      { maxDiffPixelRatio: 0.08 }
+    );
+  });
+
+  test("error state", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-commitlistpanel--error&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot("error.png");
+  });
+
+  test("empty state", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-commitlistpanel--empty&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot("empty.png");
+  });
+});

--- a/frontend/src/components/CommitListPanel.stories.tsx
+++ b/frontend/src/components/CommitListPanel.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CommitListPanel } from "./CommitListPanel";
+import { fixtures } from "../storybook";
+
+const meta = {
+  title: "Components/CommitListPanel",
+  component: CommitListPanel,
+  args: {
+    commits: fixtures.commits,
+  },
+} satisfies Meta<typeof CommitListPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** デフォルト（コミット一覧表示） */
+export const Default: Story = {};
+
+/** ローディング状態 */
+export const Loading: Story = {
+  args: {
+    commits: [],
+    loading: true,
+  },
+};
+
+/** エラー状態 */
+export const Error: Story = {
+  args: {
+    commits: [],
+    error: "GitHub API rate limit exceeded. Please try again later.",
+  },
+};
+
+/** 空状態（コミットが0件） */
+export const Empty: Story = {
+  args: {
+    commits: [],
+  },
+};

--- a/frontend/src/components/CommitListPanel.tsx
+++ b/frontend/src/components/CommitListPanel.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from "react-i18next";
+import type { CommitInfo } from "../types";
+import { Card } from "./Card";
+import { Loading } from "./Loading";
+
+interface CommitListPanelProps {
+  commits: CommitInfo[];
+  loading?: boolean;
+  error?: string | null;
+}
+
+function formatShortSha(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function CommitListPanel({
+  commits,
+  loading = false,
+  error = null,
+}: CommitListPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Card>
+      <h2 className="mb-3 border-b border-border pb-2 text-lg text-text-heading">
+        {t("pr.commits")}
+      </h2>
+
+      {loading && <Loading />}
+
+      {error && (
+        <p className="p-2 text-[0.9rem] text-danger">
+          {t("pr.commitsError")}: {error}
+        </p>
+      )}
+
+      {!loading && !error && commits.length === 0 && (
+        <p className="p-4 text-center text-sm italic text-text-secondary">
+          {t("pr.commitsEmpty")}
+        </p>
+      )}
+
+      {!loading &&
+        !error &&
+        commits.map((commit) => (
+          <div
+            key={commit.sha}
+            className="border-b border-border px-3 py-2.5 last:border-b-0"
+          >
+            <div className="flex items-center gap-2">
+              <code className="shrink-0 rounded bg-bg-hover px-1.5 py-0.5 text-xs text-info">
+                {formatShortSha(commit.sha)}
+              </code>
+              <span className="truncate text-sm font-medium text-text-primary">
+                {commit.message}
+              </span>
+            </div>
+            <div className="mt-0.5 flex items-center gap-2 pl-[calc(1.5rem+0.75rem+0.5rem)] text-xs text-text-secondary">
+              <span>{commit.author}</span>
+              <span>{formatDate(commit.date)}</span>
+            </div>
+          </div>
+        ))}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Implements issue #372: CommitListPanel コンポーネントを作成する

## 概要

PRのコミット一覧を表示するための `CommitListPanel` コンポーネントを作成する。
バックエンド（`CommitInfo` 構造体、`list_pr_commits` Tauriコマンド）とフロントエンドの型定義（`CommitInfo`）は既に実装済みのため、純粋にUIコンポーネントの作成が対象。

## 実装内容

### `frontend/src/components/CommitListPanel.tsx`
- `CommitInfo[]` を受け取り、コミット一覧を表示するコンポーネント
- 各コミットについて sha（短縮）, message, author, date を表示
- ローディング状態とエラー状態のハンドリング
- 空の場合の表示
- 既存の `Card` コンポーネントや Tailwind スタイルを活用

### Stories & VRT
- `CommitListPanel.stories.tsx` を作成（デフォルト、ローディング、エラー、空状態のストーリー）
- `frontend/e2e/vrt/commit-list-panel.spec.ts` を作成

## Acceptance Criteria

- [ ] `CommitListPanel` コンポーネントが `CommitInfo[]` を受け取りコミット一覧を表示する
- [ ] ローディング・エラー・空状態が正しく表示される
- [ ] Storybook の Stories が追加されている
- [ ] VRT スペックが追加されている

Parent: #130

Closes #372

---
Generated by agent/loop.sh