### PR TITLE
fix: Layout/Sidebar: 選択中リポジトリの強調がアクセントカラーのみで弱い

### DIFF
--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -193,6 +193,29 @@ describe("Sidebar", () => {
     expect(selectedItem).toBeInTheDocument();
   });
 
+  it("shows checkmark icon for selected repository", () => {
+    const { container } = render(
+      <Sidebar {...defaultProps} selectedPath="/Users/dev/project" />
+    );
+    const selectedItem = container.querySelector('[aria-current="true"]');
+    expect(selectedItem).toBeInTheDocument();
+    const checkIcon = selectedItem!.querySelector("svg[aria-hidden='true']");
+    expect(checkIcon).toBeInTheDocument();
+  });
+
+  it("does not show checkmark icon for non-selected repositories", () => {
+    const { container } = render(
+      <Sidebar {...defaultProps} selectedPath="/Users/dev/project" />
+    );
+    const nonSelectedItems = container.querySelectorAll(
+      ".border-l-transparent"
+    );
+    nonSelectedItems.forEach((item) => {
+      const checkIcon = item.querySelector("svg[aria-hidden='true']");
+      expect(checkIcon).not.toBeInTheDocument();
+    });
+  });
+
   it("shows tooltip with repo name and path on hover", async () => {
     const user = userEvent.setup();
     render(<Sidebar {...defaultProps} />);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,23 @@ import type { RepositoryEntry } from "../types";
 
 const THEME_OPTIONS: Theme[] = ["light", "dark", "system"];
 
+const CheckIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
 const SettingsGearIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -136,8 +153,16 @@ export function Sidebar({
                       name: repo.name,
                     })}
                   >
-                    <span className="text-sm font-medium">
-                      {repo.name.charAt(0).toUpperCase()}
+                    <span className="flex flex-col items-center gap-0.5">
+                      <span className="text-sm font-medium">
+                        {repo.name.charAt(0).toUpperCase()}
+                      </span>
+                      {selectedPath === repo.path && (
+                        <span
+                          className="h-1 w-1 rounded-full bg-accent"
+                          aria-hidden="true"
+                        />
+                      )}
                     </span>
                   </button>
                 </Tooltip.Trigger>
@@ -169,10 +194,15 @@ export function Sidebar({
                     : "border-l-2 border-l-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
                 }`}
               >
+                {selectedPath === repo.path && (
+                  <span className="mr-1.5 flex shrink-0 items-center text-accent">
+                    <CheckIcon />
+                  </span>
+                )}
                 <Tooltip.Root>
                   <Tooltip.Trigger asChild>
                     <button
-                      className="flex-1 cursor-pointer truncate rounded border-none bg-transparent text-left text-inherit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                      className="min-w-0 flex-1 cursor-pointer truncate rounded border-none bg-transparent text-left text-inherit focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                       onClick={() => onSelect(repo.path)}
                       aria-label={t("repository.selectAriaLabel", {
                         name: repo.name,


### PR DESCRIPTION
## Summary

Implements issue #356: Layout/Sidebar: 選択中リポジトリの強調がアクセントカラーのみで弱い

## 概要

左ボーダー＋テキスト色の変化だけでは、色覚特性を持つユーザーには選択状態が伝わりにくい。

## 対応方針

背景色（`bg-bg-hover`）に加えてアイコンやチェックマークで状態を補強する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

ビジュアルデザイン

Closes #356

---
Generated by agent/loop.sh