### PR TITLE
fix: Layout/Sidebar: Settings ボタンのレイアウトが非対称で一貫性がない

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -326,7 +326,9 @@ export function Sidebar({
             )}
           </div>
         )}
-        <div className="border-t border-border px-4 py-3">
+        <div
+          className={`border-t border-border ${collapsed ? "px-2" : "px-4"} py-3`}
+        >
           {collapsed ? (
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
@@ -359,7 +361,7 @@ export function Sidebar({
             <>
               <button
                 onClick={onToggleSettings}
-                className={`flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-2 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                className={`flex w-full cursor-pointer items-center gap-2 rounded border-none bg-transparent px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                   settingsOpen
                     ? "text-accent"
                     : "text-text-secondary hover:text-text-primary"


### PR DESCRIPTION
## Summary

Implements issue #359: Layout/Sidebar: Settings ボタンのレイアウトが非対称で一貫性がない

## 概要

Settings ボタンはアイコン＋テキストの組み合わせだが、全幅を使っておらず左寄り・余白が非対称。ボタン全体のレイアウト一貫性が欠けている。

## 対応方針

ボタンのパディングとレイアウトを他のボタンと統一する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

ビジュアルデザイン

Closes #359

---
Generated by agent/loop.sh