### PR TITLE
fix: Layout/Sidebar: タグラインがナビゲーション UI の中に混在し情報階層が乱れている

### DIFF
--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -10,7 +10,6 @@ vi.mock("react-i18next", () => ({
       const translations: Record<string, string> = {
         "repository.selectPrompt": "リポジトリを選択してください",
         "app.title": "reown",
-        "app.tagline": "tagline",
         "repository.title": "Repositories",
         "repository.empty": "リポジトリがありません",
         "repository.add": "リポジトリを追加",

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -14,7 +14,6 @@ vi.mock("react-i18next", () => ({
     t: (key: string, opts?: Record<string, string>) => {
       const translations: Record<string, string> = {
         "app.title": "reown",
-        "app.tagline": "tagline",
         "repository.title": "Repositories",
         "repository.empty": "リポジトリがありません",
         "repository.add": "リポジトリを追加",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -433,11 +433,6 @@ export function Sidebar({
             </button>
           </div>
         )}
-        {!collapsed && (
-          <div className="border-t border-border px-4 py-3">
-            <p className="text-xs text-text-muted">{t("app.tagline")}</p>
-          </div>
-        )}
         <ConfirmDialog
           open={removingRepo !== null}
           message={


### PR DESCRIPTION
## Summary

Implements issue #360: Layout/Sidebar: タグラインがナビゲーション UI の中に混在し情報階層が乱れている

## 概要

「エージェントPRの嵐の時代でも…」という文章がナビゲーション UI の中に混在しており、情報階層が乱れている。

## 対応方針

ログイン画面やスプラッシュへ移動するか、サイドバーから削除する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

ビジュアルデザイン

Closes #360

---
Generated by agent/loop.sh