### PR TITLE
feat: Layout/Sidebar: Settings の開閉状態の表示パターンが未定義

### DIFF
--- a/frontend/e2e/vrt/layout.spec.ts
+++ b/frontend/e2e/vrt/layout.spec.ts
@@ -76,6 +76,15 @@ test.describe("Layout", () => {
     );
   });
 
+  test("settings open", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-layout--settings-open&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "settings-open.png"
+    );
+  });
+
   test("loading repositories", async ({ page }) => {
     await page.goto(
       "/iframe.html?id=components-layout--loading&viewMode=story"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -169,6 +169,12 @@ export function App() {
           }}
           settingsOpen={settingsOpen}
           onToggleSettings={() => setSettingsOpen((prev) => !prev)}
+          settingsContent={
+            <div className="mx-auto max-w-xl space-y-8">
+              <LlmSettingsTab />
+              <AutomationSettingsTab />
+            </div>
+          }
           branchSelector={
             <BranchSelector
               prs={prs}
@@ -177,19 +183,10 @@ export function App() {
             />
           }
         >
-          {settingsOpen ? (
-            <div className="mx-auto max-w-xl space-y-8">
-              <LlmSettingsTab />
-              <AutomationSettingsTab />
-            </div>
-          ) : (
-            <>
-              {activeTab === "review" && (
-                <ReviewTab selectedBranch={selectedBranch} prs={prs} />
-              )}
-              {activeTab === "next-action" && <TodoTab />}
-            </>
+          {activeTab === "review" && (
+            <ReviewTab selectedBranch={selectedBranch} prs={prs} />
           )}
+          {activeTab === "next-action" && <TodoTab />}
         </Layout>
       </RepositoryProvider>
     </ThemeProvider>

--- a/frontend/src/components/Layout.stories.tsx
+++ b/frontend/src/components/Layout.stories.tsx
@@ -84,6 +84,27 @@ export const SidebarResized: Story = {
   ],
 };
 
+export const SettingsOpen: Story = {
+  args: {
+    settingsOpen: true,
+    onToggleSettings: fn(),
+    settingsContent: (
+      <div className="mx-auto max-w-xl space-y-8">
+        <div className="rounded-lg border border-border bg-bg-primary p-5">
+          <h2 className="text-lg font-semibold text-text-primary">LLM設定</h2>
+          <p className="mt-2 text-sm text-text-muted">設定コンテンツ領域</p>
+        </div>
+        <div className="rounded-lg border border-border bg-bg-primary p-5">
+          <h2 className="text-lg font-semibold text-text-primary">
+            オートメーション設定
+          </h2>
+          <p className="mt-2 text-sm text-text-muted">設定コンテンツ領域</p>
+        </div>
+      </div>
+    ),
+  },
+};
+
 export const Loading: Story = {
   args: {
     loadingRepos: true,

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,6 +37,7 @@ interface Props {
   onSelectTab: (id: string) => void;
   settingsOpen?: boolean;
   onToggleSettings?: () => void;
+  settingsContent?: ReactNode;
   branchSelector?: ReactNode;
   children: ReactNode;
 }
@@ -56,6 +57,7 @@ export function Layout({
   onSelectTab,
   settingsOpen,
   onToggleSettings,
+  settingsContent,
   branchSelector,
   children,
 }: Props) {
@@ -279,25 +281,63 @@ export function Layout({
                   <line x1="3" y1="18" x2="21" y2="18" />
                 </svg>
               </button>
-              {branchSelector && (
+              {!settingsOpen && branchSelector && (
                 <div className="shrink-0 border-r border-border px-4 py-2">
                   {branchSelector}
                 </div>
               )}
-              <TabBar
-                items={navItems}
-                activeId={activeTabId}
-                onSelect={onSelectTab}
-              />
+              {settingsOpen ? (
+                <div className="flex flex-1 items-center justify-between px-4 py-2">
+                  <h1 className="text-sm font-semibold text-text-primary">
+                    {t("tabs.settings")}
+                  </h1>
+                  <button
+                    onClick={onToggleSettings}
+                    className="cursor-pointer rounded border-none bg-transparent p-1 text-text-muted transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    aria-label={t("tabs.settingsCloseAriaLabel")}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+              ) : (
+                <TabBar
+                  items={navItems}
+                  activeId={activeTabId}
+                  onSelect={onSelectTab}
+                />
+              )}
             </div>
-            <main
-              role="tabpanel"
-              id={`tabpanel-${activeTabId}`}
-              aria-labelledby={`tab-${activeTabId}`}
-              className="scrollbar-custom flex-1 overflow-y-auto p-8"
-            >
-              {children}
-            </main>
+            {settingsOpen && settingsContent ? (
+              <div
+                role="region"
+                aria-label={t("tabs.settings")}
+                className="scrollbar-custom flex-1 overflow-y-auto p-8"
+              >
+                {settingsContent}
+              </div>
+            ) : (
+              <main
+                role="tabpanel"
+                id={`tabpanel-${activeTabId}`}
+                aria-labelledby={`tab-${activeTabId}`}
+                className="scrollbar-custom flex-1 overflow-y-auto p-8"
+              >
+                {children}
+              </main>
+            )}
           </>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-4">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -31,6 +31,7 @@
     "nextAction": "Next Action",
     "settings": "Settings",
     "settingsAriaLabel": "Open settings",
+    "settingsCloseAriaLabel": "Close settings",
     "shortcutTooltip": "Keyboard shortcut: {{key}}"
   },
   "common": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -31,6 +31,7 @@
     "nextAction": "Next Action",
     "settings": "Settings",
     "settingsAriaLabel": "設定を開く",
+    "settingsCloseAriaLabel": "設定を閉じる",
     "shortcutTooltip": "キーボードショートカット: {{key}}"
   },
   "common": {


### PR DESCRIPTION
## Summary

Implements issue #370: Layout/Sidebar: Settings の開閉状態の表示パターンが未定義

## 概要

`settingsOpen` プロップはあるが、Settings を開いたときのコンテンツ表示領域（スライドアウト？モーダル？インライン展開？）が Layout コンポーネントとして定義されておらず、パターンが不一致。

## 対応方針

設定 UI の表示パターンを統一した設計仕様を策定・実装する。

## 対象コンポーネント

- Layout
- Sidebar

## カテゴリ

コンポーネント設計

Closes #370

---
Generated by agent/loop.sh