### PR TITLE
feat: ReviewTab: ファイル差分ビューアコンポーネントを実装する

### DIFF
--- a/frontend/e2e/vrt/diff-viewer.spec.ts
+++ b/frontend/e2e/vrt/diff-viewer.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("DiffViewer", () => {
+  test("modified file", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-diffviewer--modified&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "modified.png"
+    );
+  });
+
+  test("added file", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-diffviewer--added&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "added.png"
+    );
+  });
+
+  test("deleted file", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-diffviewer--deleted&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "deleted.png"
+    );
+  });
+
+  test("multiple chunks", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-diffviewer--multiple-chunks&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "multiple-chunks.png"
+    );
+  });
+
+  test("renamed file", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-diffviewer--renamed&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "renamed.png"
+    );
+  });
+});

--- a/frontend/src/components/DiffViewer.stories.tsx
+++ b/frontend/src/components/DiffViewer.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DiffViewer } from "./DiffViewer";
+import { fixtures } from "../storybook";
+
+const meta = {
+  title: "Components/DiffViewer",
+  component: DiffViewer,
+  args: {
+    diff: fixtures.fileDiffs[0],
+  },
+} satisfies Meta<typeof DiffViewer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Modified ファイル（追加・削除・コンテキスト行を含む） */
+export const Modified: Story = {};
+
+/** Added ファイル（全行が追加行） */
+export const Added: Story = {
+  args: {
+    diff: fixtures.fileDiffs[1],
+  },
+};
+
+/** Deleted ファイル（チャンクなし、バイナリメッセージ表示） */
+export const Deleted: Story = {
+  args: {
+    diff: fixtures.fileDiffs[2],
+  },
+};
+
+/** 複数チャンクのファイル（チャンク間セパレーター表示） */
+export const MultipleChunks: Story = {
+  args: {
+    diff: {
+      old_path: "src/utils/helpers.ts",
+      new_path: "src/utils/helpers.ts",
+      status: "Modified",
+      chunks: [
+        {
+          header: "@@ -5,4 +5,6 @@ export function formatDate()",
+          lines: [
+            {
+              origin: "Context",
+              old_lineno: 5,
+              new_lineno: 5,
+              content: "  const d = new Date(input);",
+            },
+            {
+              origin: "Deletion",
+              old_lineno: 6,
+              new_lineno: null,
+              content: '  return d.toLocaleDateString("en-US");',
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 6,
+              content: '  return d.toLocaleDateString("ja-JP");',
+            },
+            {
+              origin: "Context",
+              old_lineno: 7,
+              new_lineno: 7,
+              content: "}",
+            },
+          ],
+        },
+        {
+          header: "@@ -20,3 +22,8 @@ export function truncate()",
+          lines: [
+            {
+              origin: "Context",
+              old_lineno: 20,
+              new_lineno: 22,
+              content: "  return str.slice(0, len);",
+            },
+            {
+              origin: "Context",
+              old_lineno: 21,
+              new_lineno: 23,
+              content: "}",
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 24,
+              content: "",
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 25,
+              content: "export function capitalize(str: string): string {",
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 26,
+              content: "  return str.charAt(0).toUpperCase() + str.slice(1);",
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 27,
+              content: "}",
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+/** Renamed ファイル */
+export const Renamed: Story = {
+  args: {
+    diff: {
+      old_path: "src/old-name.ts",
+      new_path: "src/new-name.ts",
+      status: "Renamed",
+      chunks: [
+        {
+          header: "@@ -1,3 +1,3 @@",
+          lines: [
+            {
+              origin: "Deletion",
+              old_lineno: 1,
+              new_lineno: null,
+              content: 'export const NAME = "old";',
+            },
+            {
+              origin: "Addition",
+              old_lineno: null,
+              new_lineno: 1,
+              content: 'export const NAME = "new";',
+            },
+            {
+              origin: "Context",
+              old_lineno: 2,
+              new_lineno: 2,
+              content: "",
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/frontend/src/components/DiffViewer.tsx
+++ b/frontend/src/components/DiffViewer.tsx
@@ -1,0 +1,121 @@
+import { useTranslation } from "react-i18next";
+import type { FileDiff, DiffChunk } from "../types";
+import { Badge } from "./Badge";
+
+interface DiffViewerProps {
+  diff: FileDiff;
+  className?: string;
+}
+
+const statusBadgeVariant: Record<
+  FileDiff["status"],
+  "success" | "danger" | "warning" | "info" | "default"
+> = {
+  Added: "success",
+  Deleted: "danger",
+  Modified: "warning",
+  Renamed: "info",
+  Other: "default",
+};
+
+function getOriginString(
+  origin: "Addition" | "Deletion" | "Context" | { Other: string }
+): string {
+  if (typeof origin === "string") return origin;
+  return "Other";
+}
+
+function ChunkView({ chunk }: { chunk: DiffChunk }) {
+  return (
+    <div>
+      <div className="border-y border-border bg-diff-header-bg px-3 py-1 text-xs text-info">
+        {chunk.header}
+      </div>
+      {chunk.lines.map((line, li) => {
+        const origin = getOriginString(line.origin);
+        const lineClass =
+          origin === "Addition"
+            ? "diff-line-addition"
+            : origin === "Deletion"
+              ? "diff-line-deletion"
+              : "";
+        const prefix =
+          origin === "Addition" ? "+" : origin === "Deletion" ? "-" : " ";
+        const textColor =
+          origin === "Addition"
+            ? "text-accent"
+            : origin === "Deletion"
+              ? "text-danger"
+              : "text-text-secondary";
+        return (
+          <div key={li} className={`flex whitespace-pre ${lineClass}`}>
+            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-muted">
+              {line.old_lineno ?? ""}
+            </span>
+            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-muted">
+              {line.new_lineno ?? ""}
+            </span>
+            <span className={`flex-1 px-2 ${textColor}`}>
+              {prefix}
+              {line.content}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChunkSeparator() {
+  return (
+    <div className="flex items-center gap-2 bg-bg-secondary px-3 py-1">
+      <div className="h-px flex-1 bg-border" />
+      <span className="text-xs text-text-muted">...</span>
+      <div className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
+function filePath(diff: FileDiff): string {
+  return diff.new_path ?? diff.old_path ?? "";
+}
+
+export function DiffViewer({ diff, className = "" }: DiffViewerProps) {
+  const { t } = useTranslation();
+  const path = filePath(diff);
+
+  return (
+    <div
+      className={`overflow-hidden rounded-lg border border-border ${className}`}
+    >
+      {/* File header */}
+      <div className="flex items-center gap-2 border-b border-border bg-bg-secondary px-3 py-2">
+        <Badge variant={statusBadgeVariant[diff.status]}>{diff.status}</Badge>
+        <span className="truncate font-mono text-[0.8rem] font-semibold text-text-heading">
+          {path}
+        </span>
+        {diff.status === "Renamed" && diff.old_path && (
+          <span className="truncate text-[0.75rem] text-text-muted">
+            ← {diff.old_path}
+          </span>
+        )}
+      </div>
+
+      {/* Diff content */}
+      <div className="scrollbar-custom overflow-x-auto bg-bg-primary font-mono text-[0.8rem] leading-relaxed">
+        {diff.chunks.length === 0 ? (
+          <p className="p-3 text-[0.85rem] italic text-text-secondary">
+            {t("diff.noDiffContent")}
+          </p>
+        ) : (
+          diff.chunks.map((chunk, ci) => (
+            <div key={ci}>
+              {ci > 0 && <ChunkSeparator />}
+              <ChunkView chunk={chunk} />
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements issue #414: ReviewTab: ファイル差分ビューアコンポーネントを実装する

## 概要

レビューの中核機能であるファイル差分表示が未実装。バックエンドには `diff_branches` / `get_pull_request_files` が存在し、`FileDiff` / `DiffChunk` 型も定義済みだが、差分をレンダリングするフロントエンドコンポーネントがない。

PR のファイル一覧（`PrListView` → `ChangeSummaryList`）から個別ファイルを選択した際に、行レベルの差分を表示するコンポーネントを作成する。

## 実装内容

- `frontend/src/components/DiffViewer.tsx` を新規作成
  - `FileDiff` 型を受け取り、追加行・削除行・コンテキスト行を色分け表示する
  - unified diff 形式（GitHub 風）で表示
  - 行番号（old/new）を左側に表示
  - チャンク間のセパレーターを表示
- Stories（`DiffViewer.stories.tsx`）と VRT スペックを追加

## Acceptance Criteria

- [ ] `DiffViewer` コンポーネントが `FileDiff` を受け取り差分を描画する
- [ ] 追加行（緑）、削除行（赤）、コンテキスト行が視覚的に区別できる
- [ ] 行番号（old line / new line）が表示される
- [ ] チャンク間のセパレーターが表示される
- [ ] ダークモード対応
- [ ] Stories + VRT が追加されている
- [ ] `cargo test` / `cargo clippy` がパスする

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #414

---
Generated by agent/loop.sh