### PR TITLE
feat: ReviewTab: PR選択時にファイル差分を取得・表示する統合フローを実装する

### DIFF
--- a/frontend/e2e/vrt/review-tab.spec.ts
+++ b/frontend/e2e/vrt/review-tab.spec.ts
@@ -67,4 +67,27 @@ test.describe("ReviewTab", () => {
       "with-pr-info.png"
     );
   });
+
+  test("pr files loading", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-reviewtab--pr-files-loading&viewMode=story"
+    );
+    await page.waitForSelector("text=PR情報", { timeout: 10_000 });
+    await page.waitForSelector('[role="status"]', { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "pr-files-loading.png",
+      { maxDiffPixelRatio: 0.08 }
+    );
+  });
+
+  test("pr files error", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-reviewtab--pr-files-error&viewMode=story"
+    );
+    await page.waitForSelector("text=PR情報", { timeout: 10_000 });
+    await page.waitForSelector("text=GitHub API", { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "pr-files-error.png"
+    );
+  });
 });

--- a/frontend/src/components/ReviewTab.stories.tsx
+++ b/frontend/src/components/ReviewTab.stories.tsx
@@ -115,3 +115,65 @@ export const WithPrInfo: Story = {
     },
   ],
 };
+
+/** PRファイル差分ローディング状態 */
+export const PrFilesLoading: Story = {
+  args: {
+    selectedBranch: "feature/auth",
+    prs: fixtures.pullRequests,
+  },
+  decorators: [
+    (Story) => {
+      overrideInvoke({
+        diff_branches: () => fixtures.fileDiffs,
+        load_app_config: () => ({
+          ...fixtures.appConfig,
+          github_token: "ghp_dummy",
+        }),
+        get_pull_request_files: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        analyze_pr_risk: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        analyze_pr_risk_with_llm: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+      });
+      return <Story />;
+    },
+  ],
+};
+
+/** PRファイル差分エラー状態 */
+export const PrFilesError: Story = {
+  args: {
+    selectedBranch: "feature/auth",
+    prs: fixtures.pullRequests,
+  },
+  decorators: [
+    (Story) => {
+      overrideInvoke({
+        diff_branches: () => fixtures.fileDiffs,
+        load_app_config: () => ({
+          ...fixtures.appConfig,
+          github_token: "ghp_dummy",
+        }),
+        get_pull_request_files: () =>
+          Promise.reject("GitHub API rate limit exceeded"),
+        analyze_pr_risk: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        analyze_pr_risk_with_llm: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+      });
+      return <Story />;
+    },
+  ],
+};

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -222,6 +222,9 @@
     "prAuthor": "Author: {{author}}",
     "prState": "Status: {{state}}",
     "prAnalysis": "PR Analysis",
+    "prFiles": "PR Files",
+    "prFilesEmpty": "No changed files.",
+    "prFilesLoading": "Loading PR file diffs…",
     "noPr": "No PR associated with this branch."
   },
   "theme": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -222,6 +222,9 @@
     "prAuthor": "作成者: {{author}}",
     "prState": "ステータス: {{state}}",
     "prAnalysis": "PR分析",
+    "prFiles": "PRファイル一覧",
+    "prFilesEmpty": "変更ファイルがありません。",
+    "prFilesLoading": "PRのファイル差分を取得中…",
     "noPr": "このブランチに関連するPRはありません。"
   },
   "theme": {


### PR DESCRIPTION
## Summary

Implements issue #415: ReviewTab: PR選択時にファイル差分を取得・表示する統合フローを実装する

## 概要

`PrListView` で PR を選択 → `CommitListPanel` でコミット一覧を確認、までは実装済み。次のステップとして、PR のファイル差分を取得して `DiffViewer`（別 Issue で作成）と連携し、ファイルをクリックすると差分が表示されるフローを構築する。

## 前提

- `DiffViewer` コンポーネントが実装済みであること

## 実装内容

- `ReviewTab` に PR 選択時のファイル差分取得ロジックを追加
  - `get_pull_request_files` Tauri コマンドを呼び出し
  - `ChangeSummaryList` のファイル項目クリックで `DiffViewer` を表示
- ファイル差分パネルのレイアウト（右側 or 下部にスライドイン）
- ローディング状態とエラーハンドリング

## Acceptance Criteria

- [ ] PR 選択後、ファイル一覧が `ChangeSummaryList` に表示される
- [ ] ファイルをクリックすると `DiffViewer` で差分が表示される
- [ ] ローディングスピナーが差分取得中に表示される
- [ ] エラー時にユーザーフレンドリーなメッセージが表示される
- [ ] Stories + VRT が更新されている
- [ ] `cargo test` / `cargo clippy` がパスする

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #415

---
Generated by agent/loop.sh