### PR TITLE
feat: ReviewTab: PRコミット一覧をレビュー画面に表示する

### DIFF
--- a/frontend/e2e/vrt/review-tab.spec.ts
+++ b/frontend/e2e/vrt/review-tab.spec.ts
@@ -63,6 +63,7 @@ test.describe("ReviewTab", () => {
       "/iframe.html?id=components-reviewtab--with-pr-info&viewMode=story"
     );
     await page.waitForSelector("text=PR情報", { timeout: 10_000 });
+    await page.waitForSelector("text=コミット一覧", { timeout: 10_000 });
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
       "with-pr-info.png"
     );
@@ -86,6 +87,7 @@ test.describe("ReviewTab", () => {
     );
     await page.waitForSelector("text=PR情報", { timeout: 10_000 });
     await page.waitForSelector("text=GitHub API", { timeout: 10_000 });
+    await page.waitForSelector("text=コミット一覧", { timeout: 10_000 });
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
       "pr-files-error.png"
     );

--- a/frontend/src/components/ReviewTab.stories.tsx
+++ b/frontend/src/components/ReviewTab.stories.tsx
@@ -108,6 +108,7 @@ export const WithPrInfo: Story = {
           github_token: "ghp_dummy",
         }),
         get_pull_request_files: () => fixtures.categorizedFileDiffs,
+        list_pr_commits: () => fixtures.commits,
         analyze_pr_risk: () => fixtures.analysisResult,
         analyze_pr_risk_with_llm: () => fixtures.hybridAnalysisResult,
       });
@@ -131,6 +132,10 @@ export const PrFilesLoading: Story = {
           github_token: "ghp_dummy",
         }),
         get_pull_request_files: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        list_pr_commits: () =>
           new Promise(() => {
             /* never resolves */
           }),
@@ -164,6 +169,7 @@ export const PrFilesError: Story = {
         }),
         get_pull_request_files: () =>
           Promise.reject("GitHub API rate limit exceeded"),
+        list_pr_commits: () => fixtures.commits,
         analyze_pr_risk: () =>
           new Promise(() => {
             /* never resolves */


### PR DESCRIPTION
## Summary

Implements issue #418: ReviewTab: PRコミット一覧をレビュー画面に表示する

## 概要

ReviewTabでPRを選択した際に、そのPRに含まれるコミット一覧を表示する。現在、`CommitListPanel` コンポーネントと `list_pr_commits` Tauriコマンドは実装済みだが、ReviewTab には統合されていない。コミット一覧はレビュー時に変更の経緯を把握する上で重要な情報であり、既存のPR情報セクションの直下に表示する。

## 実装内容

- ReviewTab の `PrAnalysisSection` 内（PR情報カードの後、リスク分析の前）に `CommitListPanel` を配置する
- `list_pr_commits` を呼び出してコミット一覧を取得する
- ローディング・エラー状態を適切にハンドリングする
- Stories と VRT を更新する

## Acceptance Criteria

- [ ] ReviewTab で PR が選択された時にコミット一覧が表示される
- [ ] コミットの SHA（短縮）、メッセージ、著者、日時が表示される
- [ ] ローディング中はスピナーが表示される
- [ ] Stories が更新されている
- [ ] VRT スペックが更新されている

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #418

---
Generated by agent/loop.sh