### PR TITLE
feat: App: GitHub PR一覧の自動取得を実装する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { Layout } from "./components/Layout";
 import { RepositoryProvider } from "./RepositoryContext";
 import { ThemeProvider } from "./ThemeContext";
 import { invoke } from "./invoke";
-import type { RepositoryEntry, RepoInfo } from "./types";
+import type { RepositoryEntry, RepoInfo, PrInfo } from "./types";
 import "./style.css";
 
 const NAV_ITEMS = [
@@ -26,6 +26,8 @@ export function App() {
   const [repositories, setRepositories] = useState<RepositoryEntry[]>([]);
   const [selectedRepoPath, setSelectedRepoPath] = useState<string | null>(null);
   const [repoInfo, setRepoInfo] = useState<RepoInfo | null>(null);
+  const [prs, setPrs] = useState<PrInfo[]>([]);
+  const [loadingPrs, setLoadingPrs] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [addingRepo, setAddingRepo] = useState(false);
   const [addRepoError, setAddRepoError] = useState<string | null>(null);
@@ -43,6 +45,48 @@ export function App() {
       .then(setRepoInfo)
       .catch(() => setRepoInfo(null));
   }, [selectedRepoPath]);
+
+  useEffect(() => {
+    if (!repoInfo?.github_owner || !repoInfo?.github_repo) {
+      setPrs([]);
+      return;
+    }
+    const owner = repoInfo.github_owner;
+    const repo = repoInfo.github_repo;
+    let cancelled = false;
+
+    (async () => {
+      setLoadingPrs(true);
+      try {
+        const config = await invoke("load_app_config");
+        if (cancelled) return;
+        if (!config.github_token) {
+          setPrs([]);
+          return;
+        }
+        const result = await invoke("list_pull_requests", {
+          owner,
+          repo,
+          token: config.github_token,
+        });
+        if (!cancelled) {
+          setPrs(result);
+        }
+      } catch {
+        if (!cancelled) {
+          setPrs([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingPrs(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repoInfo]);
 
   const loadRepositories = useCallback(async () => {
     setLoadingRepos(true);
@@ -177,7 +221,9 @@ export function App() {
             </div>
           }
         >
-          {activeTab === "review" && <ReviewTab />}
+          {activeTab === "review" && (
+            <ReviewTab prs={prs} loadingPrs={loadingPrs} />
+          )}
           {activeTab === "next-action" && <TodoTab />}
           {activeTab === "automate" && <AutomationSettingsTab />}
         </Layout>

--- a/frontend/src/components/ReviewTab.tsx
+++ b/frontend/src/components/ReviewTab.tsx
@@ -70,7 +70,12 @@ const categoryBadgeVariant: Record<
   Other: "default",
 };
 
-export function ReviewTab() {
+interface ReviewTabProps {
+  prs?: PrInfo[];
+  loadingPrs?: boolean;
+}
+
+export function ReviewTab({ prs = [], loadingPrs = false }: ReviewTabProps) {
   const { t } = useTranslation();
   const { repoPath, repoInfo } = useRepository();
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
@@ -199,10 +204,13 @@ export function ReviewTab() {
     <div className="space-y-4">
       <div className="flex items-center gap-3">
         <BranchSelector
-          prs={[]}
+          prs={prs}
           selectedBranch={selectedBranch}
           onSelectBranch={setSelectedBranch}
         />
+        {loadingPrs && (
+          <span className="text-xs text-text-muted">{t("pr.loadingPrs")}</span>
+        )}
       </div>
 
       {/* No branch selected */}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -174,7 +174,8 @@
     "autoApproveResultFailed": "Failed",
     "autoApproveMergeEnabled": "Auto Merge: Enabled",
     "autoApproveMergeSkipped": "Auto Merge: Skipped",
-    "autoApproveMergeFailed": "Auto Merge: Failed"
+    "autoApproveMergeFailed": "Auto Merge: Failed",
+    "loadingPrs": "Loading PRs…"
   },
   "llmSettings": {
     "title": "LLM Settings",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -174,7 +174,8 @@
     "autoApproveResultFailed": "失敗",
     "autoApproveMergeEnabled": "Auto Merge: 有効",
     "autoApproveMergeSkipped": "Auto Merge: スキップ",
-    "autoApproveMergeFailed": "Auto Merge: 失敗"
+    "autoApproveMergeFailed": "Auto Merge: 失敗",
+    "loadingPrs": "PR取得中…"
   },
   "llmSettings": {
     "title": "LLM設定",


### PR DESCRIPTION
## Summary

Implements issue #428: App: GitHub PR一覧の自動取得を実装する

## 概要

現在 `App.tsx` で `prs` ステートが常に空配列 `[]` のまま、GitHub PR一覧を取得する処理が実装されていない。`list_pull_requests` Tauri コマンドは存在するが、フロントエンドから呼び出されていないため、ReviewTab の PR 関連機能（PRファイル差分、リスク分析、コミット一覧、レビュー送信、オートメーション）がすべて動作しない状態になっている。

これはレビュー支援機能の根幹であり、最優先で修正が必要。

## 実装内容

- `App.tsx` でリポジトリ選択時に `load_app_config` から GitHub トークンを取得し、`repoInfo` の `github_owner` / `github_repo` を使って `list_pull_requests` を呼び出す
- 取得した PR 一覧を `prs` ステートにセットし、`BranchSelector` と `ReviewTab` に渡す
- ローディング状態とエラーハンドリングを追加する
- リポジトリ切り替え時に PR 一覧をリフレッシュする

## Acceptance Criteria

- [ ] リポジトリ選択時に GitHub PR 一覧が自動取得される
- [ ] 取得した PR が `BranchSelector` でブランチと紐づいて表示される
- [ ] `ReviewTab` でマッチする PR の情報（ファイル差分、分析等）が表示される
- [ ] GitHub トークン未設定時はエラーではなく、PR 一覧が空のまま動作する
- [ ] ローディング中の状態表示がある
- [ ] 既存のテスト・Stories が壊れない

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #428

---
Generated by agent/loop.sh