### PR TITLE
fix: Settings: GitHub トークン設定UIを追加する

### DIFF
--- a/frontend/e2e/vrt/github-settings-tab.spec.ts
+++ b/frontend/e2e/vrt/github-settings-tab.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("GithubSettingsTab", () => {
+  test("default", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-githubsettingstab--default&viewMode=story"
+    );
+    await page.waitForSelector("text=GitHub設定", { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "default.png"
+    );
+  });
+
+  test("with token stored", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-githubsettingstab--with-token-stored&viewMode=story"
+    );
+    await page.waitForSelector("text=トークンは保存されています", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "with-token-stored.png"
+    );
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { open } from "@tauri-apps/plugin-dialog";
 import { ReviewTab } from "./components/ReviewTab";
 import { TodoTab } from "./components/TodoTab";
+import { GithubSettingsTab } from "./components/GithubSettingsTab";
 import { LlmSettingsTab } from "./components/LlmSettingsTab";
 import { AutomationSettingsTab } from "./components/AutomationSettingsTab";
 import { Layout } from "./components/Layout";
@@ -172,6 +173,7 @@ export function App() {
           onToggleSettings={() => setSettingsOpen((prev) => !prev)}
           settingsContent={
             <div className="mx-auto max-w-xl space-y-8">
+              <GithubSettingsTab />
               <LlmSettingsTab />
               <AutomationSettingsTab />
             </div>

--- a/frontend/src/components/GithubSettingsTab.stories.tsx
+++ b/frontend/src/components/GithubSettingsTab.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { GithubSettingsTab } from "./GithubSettingsTab";
+import { overrideInvoke, resetInvokeOverrides, fixtures } from "../storybook";
+
+const meta = {
+  title: "Components/GithubSettingsTab",
+  component: GithubSettingsTab,
+  decorators: [
+    (Story) => {
+      resetInvokeOverrides();
+      return <Story />;
+    },
+  ],
+} satisfies Meta<typeof GithubSettingsTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** デフォルト（トークン未設定） */
+export const Default: Story = {
+  decorators: [
+    (Story) => {
+      overrideInvoke({
+        load_app_config: () => ({
+          ...fixtures.appConfig,
+          github_token: "",
+        }),
+      });
+      return <Story />;
+    },
+  ],
+};
+
+/** トークン保存済み */
+export const WithTokenStored: Story = {
+  decorators: [
+    (Story) => {
+      overrideInvoke({
+        load_app_config: () => ({
+          ...fixtures.appConfig,
+          github_token: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        }),
+      });
+      return <Story />;
+    },
+  ],
+};

--- a/frontend/src/components/GithubSettingsTab.tsx
+++ b/frontend/src/components/GithubSettingsTab.tsx
@@ -1,0 +1,186 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Card } from "./Card";
+import { Input } from "./Input";
+import { Button } from "./Button";
+import { invoke } from "../invoke";
+
+export function GithubSettingsTab() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState("");
+  const [tokenStored, setTokenStored] = useState(false);
+  const [showToken, setShowToken] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  const loadConfig = useCallback(async () => {
+    try {
+      setLoading(true);
+      const config = await invoke("load_app_config");
+      setTokenStored(config.github_token !== "");
+      setToken("");
+    } catch (e) {
+      setMessage({
+        type: "error",
+        text: t("githubSettings.loadError", {
+          message: e instanceof Error ? e.message : String(e),
+        }),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleSave = useCallback(async () => {
+    try {
+      setSaving(true);
+      setMessage(null);
+
+      const config = await invoke("load_app_config");
+      config.github_token = token;
+      await invoke("save_app_config", { config });
+
+      setTokenStored(true);
+      setToken("");
+      setMessage({ type: "success", text: t("githubSettings.saveSuccess") });
+    } catch (e) {
+      setMessage({
+        type: "error",
+        text: t("githubSettings.saveError", {
+          message: e instanceof Error ? e.message : String(e),
+        }),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [token, t]);
+
+  const handleReset = useCallback(() => {
+    setMessage(null);
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      setMessage(null);
+
+      const config = await invoke("load_app_config");
+      config.github_token = "";
+      await invoke("save_app_config", { config });
+
+      setTokenStored(false);
+      setToken("");
+      setMessage({
+        type: "success",
+        text: t("githubSettings.tokenDeleted"),
+      });
+    } catch (e) {
+      setMessage({
+        type: "error",
+        text: t("common.error", {
+          message: e instanceof Error ? e.message : String(e),
+        }),
+      });
+    }
+  }, [t]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-text-muted">{t("common.loading")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-bold text-text-heading">
+          {t("githubSettings.title")}
+        </h2>
+        <p className="mt-1 text-[0.85rem] text-text-muted">
+          {t("githubSettings.description")}
+        </p>
+      </div>
+
+      <Card>
+        <div className="space-y-4">
+          <div>
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Input
+                  label={t("githubSettings.token")}
+                  type={showToken ? "text" : "password"}
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  placeholder={
+                    tokenStored
+                      ? t("githubSettings.tokenStoredPlaceholder")
+                      : t("githubSettings.tokenPlaceholder")
+                  }
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="md"
+                onClick={() => setShowToken((v) => !v)}
+                className="mb-0"
+              >
+                {showToken
+                  ? t("githubSettings.hideToken")
+                  : t("githubSettings.showToken")}
+              </Button>
+            </div>
+            {tokenStored && (
+              <div className="mt-1 flex items-center gap-2">
+                <span className="text-[0.75rem] text-success">
+                  {t("githubSettings.tokenStored")}
+                </span>
+                <button
+                  onClick={handleDelete}
+                  className="cursor-pointer border-none bg-transparent text-[0.75rem] text-danger hover:underline"
+                >
+                  {t("githubSettings.deleteToken")}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {message && (
+        <div
+          className={`rounded border px-4 py-2 text-[0.85rem] ${
+            message.type === "success"
+              ? "border-success/30 bg-success/10 text-success"
+              : "border-danger/30 bg-danger/10 text-danger"
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={handleSave}
+          variant="primary"
+          loading={saving}
+          disabled={!token}
+        >
+          {t("githubSettings.save")}
+        </Button>
+        <Button onClick={handleReset} variant="secondary">
+          {t("githubSettings.reset")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -176,6 +176,23 @@
     "autoApproveMergeSkipped": "Auto Merge: Skipped",
     "autoApproveMergeFailed": "Auto Merge: Failed"
   },
+  "githubSettings": {
+    "title": "GitHub Settings",
+    "description": "Configure your GitHub Personal Access Token. Required for PR fetching, review submission, and automation.",
+    "token": "Personal Access Token",
+    "tokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxx",
+    "tokenStoredPlaceholder": "Stored (enter a new token to update)",
+    "tokenStored": "Token is stored",
+    "deleteToken": "Delete token",
+    "tokenDeleted": "Token deleted",
+    "showToken": "Show",
+    "hideToken": "Hide",
+    "save": "Save",
+    "reset": "Reset",
+    "saveSuccess": "GitHub token saved successfully",
+    "saveError": "Failed to save GitHub token: {{message}}",
+    "loadError": "Failed to load settings: {{message}}"
+  },
   "llmSettings": {
     "title": "LLM Settings",
     "endpoint": "Endpoint URL",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -176,6 +176,23 @@
     "autoApproveMergeSkipped": "Auto Merge: スキップ",
     "autoApproveMergeFailed": "Auto Merge: 失敗"
   },
+  "githubSettings": {
+    "title": "GitHub設定",
+    "description": "GitHub Personal Access Tokenを設定します。PR取得・レビュー送信・オートメーションに必要です。",
+    "token": "Personal Access Token",
+    "tokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxx",
+    "tokenStoredPlaceholder": "保存済み（変更する場合は新しいトークンを入力）",
+    "tokenStored": "トークンは保存されています",
+    "deleteToken": "トークンを削除",
+    "tokenDeleted": "トークンを削除しました",
+    "showToken": "表示",
+    "hideToken": "非表示",
+    "save": "保存",
+    "reset": "リセット",
+    "saveSuccess": "GitHubトークンを保存しました",
+    "saveError": "GitHubトークンの保存に失敗しました: {{message}}",
+    "loadError": "設定の読み込みに失敗しました: {{message}}"
+  },
   "llmSettings": {
     "title": "LLM設定",
     "endpoint": "エンドポイントURL",


### PR DESCRIPTION
## Summary

Implements issue #430: Settings: GitHub トークン設定UIを追加する

## 概要

`AppConfig` に `github_token` フィールドがあり、PR取得・レビュー送信・オートメーションすべてに必要だが、フロントエンドにGitHubトークンを設定するUIが存在しない。`LlmSettingsTab` と `AutomationSettingsTab` はあるが、GitHubトークン設定タブがない。

現状ユーザーがGitHub連携機能を使うための設定手段がなく、全PR機能がブロックされている。

## 実装内容

- `GitHubSettingsTab` コンポーネントを新規作成する
- GitHub Personal Access Token の入力・保存・削除 UI を実装
- トークン設定済みかどうかの状態表示（マスクされた表示）
- `Layout` の Settings パネルに `GitHubSettingsTab` を追加
- 保存時に `save_app_config` Tauri コマンドを呼び出す

## Acceptance Criteria

- [ ] Settings パネルに GitHub トークン設定セクションが表示される
- [ ] トークンを入力して保存できる
- [ ] 保存済みトークンがマスク表示される
- [ ] トークンを削除（クリア）できる
- [ ] Stories と VRT が追加される

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #430

---
Generated by agent/loop.sh