### PR TITLE
feat: ReviewTab: LLM PR要約パネルを表示する

### DIFF
--- a/frontend/e2e/vrt/pr-summary-panel.spec.ts
+++ b/frontend/e2e/vrt/pr-summary-panel.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("PrSummaryPanel", () => {
+  test("initial", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-prsummarypanel--initial&viewMode=story"
+    );
+    await page.waitForSelector("text=PR要約", { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "initial.png"
+    );
+  });
+
+  test("loading", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-prsummarypanel--loading&viewMode=story"
+    );
+    await page.waitForSelector("text=認証機能を追加する", { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "loading.png",
+      { maxDiffPixelRatio: 0.08 }
+    );
+  });
+
+  test("with summary", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-prsummarypanel--with-summary&viewMode=story"
+    );
+    await page.waitForSelector("text=全体要約", { timeout: 10_000 });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "with-summary.png"
+    );
+  });
+
+  test("error", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-prsummarypanel--error&viewMode=story"
+    );
+    await page.waitForSelector("text=LLM API connection failed", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#storybook-root")).toHaveScreenshot("error.png");
+  });
+});

--- a/frontend/src/components/PrSummaryPanel.stories.tsx
+++ b/frontend/src/components/PrSummaryPanel.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within, waitFor } from "storybook/test";
+import { PrSummaryPanel } from "./PrSummaryPanel";
+import {
+  overrideInvoke,
+  resetInvokeOverrides,
+  emitMockEvent,
+  clearMockListeners,
+  fixtures,
+} from "../storybook";
+
+const meta = {
+  title: "Components/PrSummaryPanel",
+  component: PrSummaryPanel,
+  args: {
+    owner: "example",
+    repo: "reown",
+    prNumber: 42,
+    token: "ghp_dummy",
+  },
+  decorators: [
+    (Story) => {
+      resetInvokeOverrides();
+      clearMockListeners();
+      return <Story />;
+    },
+  ],
+} satisfies Meta<typeof PrSummaryPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 初期状態（生成ボタン表示） */
+export const Initial: Story = {};
+
+/** ローディング状態（Spinner + ストリーミングテキスト表示） */
+export const Loading: Story = {
+  play: async ({ canvasElement, args }) => {
+    overrideInvoke({
+      summarize_pull_request: () =>
+        new Promise(() => {
+          /* never resolves — keep loading */
+        }),
+    });
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: "AI要約を生成" });
+    await userEvent.click(button);
+    // ストリーミングテキストをシミュレート
+    await new Promise((r) => setTimeout(r, 100));
+    emitMockEvent(`summary-stream-${args.prNumber}`, "認証機能を追加する");
+    await new Promise((r) => setTimeout(r, 50));
+    emitMockEvent(`summary-stream-${args.prNumber}`, "PRです。");
+    await waitFor(() => {
+      canvas.getByText(/認証機能を追加する/);
+    });
+  },
+};
+
+/** サマリー表示状態（overall_summary + reason + file_summaries） */
+export const WithSummary: Story = {
+  play: async ({ canvasElement }) => {
+    overrideInvoke({
+      summarize_pull_request: () => fixtures.prSummary,
+    });
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: "AI要約を生成" });
+    await userEvent.click(button);
+    await waitFor(() => {
+      canvas.getByText("全体要約");
+    });
+  },
+};
+
+/** エラー状態 */
+export const Error: Story = {
+  play: async ({ canvasElement }) => {
+    overrideInvoke({
+      summarize_pull_request: () => Promise.reject("LLM API connection failed"),
+    });
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: "AI要約を生成" });
+    await userEvent.click(button);
+    await waitFor(() => {
+      canvas.getByText(/LLM API connection failed/);
+    });
+  },
+};

--- a/frontend/src/components/PrSummaryPanel.tsx
+++ b/frontend/src/components/PrSummaryPanel.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { invoke } from "../invoke";
+import type { PrSummary } from "../types";
+import { Card, Panel } from "./Card";
+import { Button } from "./Button";
+import { Spinner } from "./Loading";
+
+interface PrSummaryPanelProps {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  token: string;
+}
+
+export function PrSummaryPanel({
+  owner,
+  repo,
+  prNumber,
+  token,
+}: PrSummaryPanelProps) {
+  const { t } = useTranslation();
+  const [summary, setSummary] = useState<PrSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [streamingText, setStreamingText] = useState("");
+  const cancelledRef = useRef(false);
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+
+  // Cleanup listener on unmount
+  useEffect(() => {
+    return () => {
+      if (unlistenRef.current) {
+        unlistenRef.current();
+        unlistenRef.current = null;
+      }
+    };
+  }, []);
+
+  // Reset when PR changes
+  useEffect(() => {
+    setSummary(null);
+    setError(null);
+    setLoading(false);
+    setStreamingText("");
+  }, [prNumber]);
+
+  const handleCancel = useCallback(() => {
+    cancelledRef.current = true;
+    setLoading(false);
+    if (unlistenRef.current) {
+      unlistenRef.current();
+      unlistenRef.current = null;
+    }
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    cancelledRef.current = false;
+    setLoading(true);
+    setError(null);
+    setSummary(null);
+    setStreamingText("");
+
+    if (unlistenRef.current) {
+      unlistenRef.current();
+    }
+    try {
+      unlistenRef.current = await listen<string>(
+        `summary-stream-${prNumber}`,
+        (event) => {
+          if (!cancelledRef.current) {
+            setStreamingText((prev) => prev + event.payload);
+          }
+        }
+      );
+    } catch {
+      // Event listening is optional
+    }
+
+    try {
+      const result = await invoke("summarize_pull_request", {
+        owner: owner.trim(),
+        repo: repo.trim(),
+        prNumber,
+        token: token.trim(),
+      });
+      if (cancelledRef.current) return;
+      setSummary(result);
+      setStreamingText("");
+    } catch (err) {
+      if (!cancelledRef.current) {
+        setError(String(err));
+      }
+    } finally {
+      if (!cancelledRef.current) {
+        setLoading(false);
+      }
+      if (unlistenRef.current) {
+        unlistenRef.current();
+        unlistenRef.current = null;
+      }
+    }
+  }, [owner, repo, prNumber, token]);
+
+  return (
+    <Card className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg text-text-heading">{t("pr.prSummary")}</h2>
+        {loading ? (
+          <Button variant="secondary" size="sm" onClick={handleCancel}>
+            {t("pr.cancelGeneration")}
+          </Button>
+        ) : (
+          <Button
+            variant={summary ? "secondary" : "primary"}
+            size="sm"
+            onClick={handleGenerate}
+          >
+            {t("pr.generateSummary")}
+          </Button>
+        )}
+      </div>
+
+      {/* Loading state with streaming text */}
+      {loading && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Spinner size="sm" />
+            <span className="text-[0.85rem] text-text-secondary">
+              {t("pr.generatingSummary")}
+            </span>
+          </div>
+          {streamingText && (
+            <Panel>
+              <p className="whitespace-pre-wrap text-[0.85rem] text-text-primary">
+                {streamingText}
+                <span className="inline-block animate-pulse">|</span>
+              </p>
+            </Panel>
+          )}
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <p className="text-[0.85rem] text-danger">
+          {t("pr.summaryError")}: {error}
+        </p>
+      )}
+
+      {/* Summary content */}
+      {summary && !loading && (
+        <div className="space-y-3">
+          {/* Overall summary */}
+          <Panel>
+            <h3 className="mb-2 text-[0.85rem] font-semibold text-text-heading">
+              {t("pr.overallSummary")}
+            </h3>
+            <p className="whitespace-pre-wrap text-[0.85rem] text-text-primary">
+              {summary.overall_summary}
+            </p>
+          </Panel>
+
+          {/* Change reason */}
+          {summary.reason && (
+            <Panel>
+              <h3 className="mb-2 text-[0.85rem] font-semibold text-text-heading">
+                {t("pr.changeReason")}
+              </h3>
+              <p className="whitespace-pre-wrap text-[0.85rem] text-text-primary">
+                {summary.reason}
+              </p>
+            </Panel>
+          )}
+
+          {/* File summaries */}
+          {summary.file_summaries.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-[0.85rem] font-semibold text-text-heading">
+                {t("pr.fileSummaries")}
+              </h3>
+              {summary.file_summaries.map((file) => (
+                <Panel key={file.path} className="space-y-1">
+                  <span className="truncate font-mono text-[0.8rem] font-semibold text-info">
+                    {file.path}
+                  </span>
+                  <p className="text-[0.8rem] text-text-secondary">
+                    {file.summary}
+                  </p>
+                </Panel>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/ReviewTab.tsx
+++ b/frontend/src/components/ReviewTab.tsx
@@ -21,6 +21,7 @@ import { ConsistencyCheckPanel } from "./ConsistencyCheckPanel";
 import { ReviewSuggestionPanel } from "./ReviewSuggestionPanel";
 import { ReviewSubmit } from "./ReviewSubmit";
 import { AutomationPanel } from "./AutomationPanel";
+import { PrSummaryPanel } from "./PrSummaryPanel";
 
 function statusLabel(status: string): string {
   switch (status) {
@@ -441,6 +442,16 @@ function PrAnalysisSection({
         loading={commitsLoading}
         error={commitsError}
       />
+
+      {/* PR Summary */}
+      {token && (
+        <PrSummaryPanel
+          owner={owner}
+          repo={repo}
+          prNumber={matchedPr.number}
+          token={token}
+        />
+      )}
 
       {/* Risk analysis */}
       {analysisResult && (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -102,6 +102,7 @@
     "warningInfraLayer": "This change affects infrastructure/deployment",
     "severityWarning": "Warning",
     "severityCritical": "Critical",
+    "prSummary": "PR Summary",
     "aiSummary": "AI Summary",
     "generateSummary": "Generate AI Summary",
     "generatingSummary": "Generating summary…",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -102,6 +102,7 @@
     "warningInfraLayer": "この変更はインフラ・デプロイに影響します",
     "severityWarning": "警告",
     "severityCritical": "重大",
+    "prSummary": "PR要約",
     "aiSummary": "AI要約",
     "generateSummary": "AI要約を生成",
     "generatingSummary": "要約を生成中…",


### PR DESCRIPTION
## Summary

Implements issue #432: ReviewTab: LLM PR要約パネルを表示する

## 概要

`summarize_pull_request` Tauriコマンドは既に実装されているが、フロントエンドにPR要約（`PrSummary`）を表示するUIパネルがない。ReviewTabにPR選択後にLLM要約を取得・表示するパネルを追加する。

これにより、レビュアーはPR全体の概要とファイルごとの変更意図を素早く把握でき、1行1行コードを読む前に変更の全体像を理解できる。

## 実装内容

- `PrSummaryPanel` コンポーネントを新規作成
  - `overall_summary`（全体要約）と `reason`（変更理由）を表示
  - `file_summaries` をファイルパスごとにリスト表示
  - LLM設定未完了時は設定を促すメッセージを表示
- ReviewTab内で、PR選択時に `summarize_pull_request` を呼び出し、結果を `PrSummaryPanel` に渡す
- Stories + VRT を追加

## Acceptance Criteria

- [ ] `PrSummaryPanel` コンポーネントが `PrSummary` 型を受け取り、全体要約・理由・ファイル別要約を表示する
- [ ] ReviewTab で PR 選択後にLLM要約を取得し表示する
- [ ] ローディング中・エラー時・LLM未設定時の状態を適切に処理する
- [ ] Storybook Stories + VRT スペックが追加されている
- [ ] `cargo test` / `cargo clippy` が通る

## Pillar

review-support

---
_Proposed by agent/loop.sh propose agent_

Closes #432

---
Generated by agent/loop.sh