### PR TITLE
refactor: verify agentをdiffベースからコード状態ベースに変更

### DIFF
--- a/agent/prompts/verify.md
+++ b/agent/prompts/verify.md
@@ -4,21 +4,28 @@ You are the requirement verification agent for the **reown** project.
 
 ## Your Job
 
-Verify that the implementation (git diff) satisfies the issue's requirements.
+Verify that the current codebase satisfies the issue's requirements by directly reading and exploring the code.
 
 ## Input
 
 You will receive:
 1. The original issue title and body (requirements / acceptance criteria)
-2. The full git diff of all changes made (`git diff main...HEAD`)
+
+## Tools
+
+Use the following tools to explore the codebase:
+- **Read** — read specific files to check implementation details
+- **Glob** — find files by name patterns (e.g., `**/*.rs`, `frontend/src/components/*.tsx`)
+- **Grep** — search code for keywords, function names, types, etc.
 
 ## Rules
 
-- Compare each acceptance criterion in the issue against the diff
-- Check that the implementation addresses the core problem described
+- Explore the codebase to verify each acceptance criterion in the issue
+- Check that the implementation addressing the core problem actually exists in the code
 - Do NOT run any commands or modify any files — this is a read-only review
 - Be pragmatic: minor style differences or extra improvements are acceptable
-- Focus on whether the functional requirements are met
+- Focus on whether the functional requirements are met in the current code state
+- Look for relevant files, types, functions, and tests that demonstrate the requirements are satisfied
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- verify agentをdiffベース（`git diff main...HEAD`）からコード状態ベース（Read/Glob/Grepツール）に変更し、部分完了issueの検証精度を向上
- 実装前の事前チェックを追加し、既に完了済みのissueを実装エージェント実行前に早期終了できるようにしてコスト削減
- 05a_reqverify.shのdiff取得・埋め込みを削除し、ツール付きclaude呼び出しに統一

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `agent/prompts/verify.md` | diffベース → コード状態ベースに書き換え |
| `agent/steps/05a_reqverify.sh` | diff取得削除、`--allowedTools "Read,Glob,Grep"` 追加 |
| `agent/steps/04_implement.sh` | 実装前の事前チェックロジック追加 |

## Test plan

- [ ] `bash -n` で両シェルスクリプトの構文チェック済み
- [ ] 既に完了済みのissueに対して事前チェックが "pass" を返し、PRなしで完了することを確認
- [ ] 未完了のissueに対して事前チェックが "fail" を返し、通常の実装フローに進むことを確認
- [ ] 部分完了のissueに対してverifyステップがコード状態を正しく評価できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)