### PR TITLE
fix: ConfirmDialog: UIUX改善

### DIFF
--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -71,4 +71,22 @@ describe("ConfirmDialog", () => {
     );
     expect(screen.getByText("Extra content")).toBeInTheDocument();
   });
+
+  it("renders warning icon for destructive variant", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const icon = document.querySelector("svg[aria-hidden='true']");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("does not render warning icon for primary variant", () => {
+    render(
+      <ConfirmDialog
+        {...defaultProps}
+        confirmVariant="primary"
+        confirmLabel="OK"
+      />
+    );
+    const icon = document.querySelector("svg[aria-hidden='true']");
+    expect(icon).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -3,6 +3,22 @@ import { useTranslation } from "react-i18next";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "./Button";
 
+const WarningIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="size-6 shrink-0 text-danger"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.499-2.599 4.499H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.004ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
 interface Props {
   open: boolean;
   message: string;
@@ -23,24 +39,28 @@ export function ConfirmDialog({
   confirmVariant = "destructive",
 }: Props) {
   const { t } = useTranslation();
+  const isDestructive = confirmVariant === "destructive";
 
   return (
     <Dialog.Root open={open} onOpenChange={(v) => !v && onCancel()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[90%] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-bg-primary p-6 shadow-lg focus:outline-none">
           <Dialog.Title className="sr-only">{t("common.confirm")}</Dialog.Title>
-          <Dialog.Description className="mb-5 text-lg text-text-primary">
-            {message}
-          </Dialog.Description>
+          <div className="mb-5 flex gap-3">
+            {isDestructive && <WarningIcon />}
+            <Dialog.Description className="text-lg text-text-primary">
+              {message}
+            </Dialog.Description>
+          </div>
           {children}
-          <div className="flex justify-end gap-2">
+          <div className="flex justify-end gap-4">
             <Dialog.Close asChild>
-              <Button variant="secondary" onClick={onCancel}>
+              <Button variant="secondary" size="lg" onClick={onCancel}>
                 {t("common.cancel")}
               </Button>
             </Dialog.Close>
-            <Button variant={confirmVariant} onClick={onConfirm}>
+            <Button variant={confirmVariant} size="lg" onClick={onConfirm}>
               {confirmLabel ?? t("common.delete")}
             </Button>
           </div>


### PR DESCRIPTION
## Summary

Implements issue #450: ConfirmDialog: UIUX改善

## UIUXデザイナーレビュー指摘

### ① ダイアログの幅が狭く、ボタンが詰まっている
「キャンセル」と「削除」ボタンが隣接しており、誤タップのリスクがある。モバイル・小画面では特に危険。ボタン間の余白を広くするか、縦並びレイアウトを検討すべき。

### ② 破壊的アクションダイアログに警告の視覚強調がない
「このリポジトリを削除しますか？」という重大なアクション確認のダイアログに、警告アイコンや強調カラー（赤など）がなく、通常ダイアログと見た目が同じ。

### ③ バックドロップのオーバーレイが薄い
ダイアログ背後の薄暗いオーバーレイが認識されにくく、ダイアログがフローティングしているコンテキストが伝わりにくい。

Closes #450

---
Generated by agent/loop.sh