### PR TITLE
fix: DiffViewer: UIUX改善

### DIFF
--- a/frontend/src/components/DiffViewer.tsx
+++ b/frontend/src/components/DiffViewer.tsx
@@ -9,11 +9,11 @@ interface DiffViewerProps {
 
 const statusBadgeVariant: Record<
   FileDiff["status"],
-  "success" | "danger" | "warning" | "info" | "default"
+  "success" | "danger" | "info" | "default"
 > = {
   Added: "success",
   Deleted: "danger",
-  Modified: "warning",
+  Modified: "default",
   Renamed: "info",
   Other: "default",
 };
@@ -49,10 +49,10 @@ function ChunkView({ chunk }: { chunk: DiffChunk }) {
               : "text-text-secondary";
         return (
           <div key={li} className={`flex whitespace-pre ${lineClass}`}>
-            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-muted">
+            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-secondary">
               {line.old_lineno ?? ""}
             </span>
-            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-muted">
+            <span className="inline-block min-w-[3.5em] shrink-0 select-none border-r border-border px-2 text-right text-text-secondary">
               {line.new_lineno ?? ""}
             </span>
             <span className={`flex-1 px-2 ${textColor}`}>


### PR DESCRIPTION
## Summary

Implements issue #452: DiffViewer: UIUX改善

## UIUXデザイナーレビュー指摘

### ① ファイルステータス「Modified」のラベルカラーが橙色で目立ちすぎる
Modifiedはニュートラルな状態のはずだが、橙色は警告・注意の意味合いを持つ色として使われることが多く、意味の混乱を招く。グレー寄りの中立色が適切。

### ② 行番号のコントラストが低い
左端の行番号（10, 11, 12...）は薄いグレーで表示されており、ロービジョンユーザーには判別しにくい。アクセシビリティ上、WCAG AA基準（4.5:1）を満たす必要がある。

Closes #452

---
Generated by agent/loop.sh