### PR TITLE
fix: ReviewSubmit: UIUX改善

### DIFF
--- a/frontend/e2e/vrt/review-submit.spec.ts
+++ b/frontend/e2e/vrt/review-submit.spec.ts
@@ -5,7 +5,7 @@ test.describe("ReviewSubmit", () => {
     await page.goto(
       "/iframe.html?id=components-reviewsubmit--default&viewMode=story"
     );
-    await page.waitForSelector("text=Approve", { timeout: 10_000 });
+    await page.waitForSelector("text=#42", { timeout: 10_000 });
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
       "default.png"
     );
@@ -15,7 +15,7 @@ test.describe("ReviewSubmit", () => {
     await page.goto(
       "/iframe.html?id=components-reviewsubmit--no-analysis&viewMode=story"
     );
-    await page.waitForSelector("text=Approve", { timeout: 10_000 });
+    await page.waitForSelector("text=#42", { timeout: 10_000 });
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
       "no-analysis.png"
     );

--- a/frontend/src/components/ReviewSubmit.tsx
+++ b/frontend/src/components/ReviewSubmit.tsx
@@ -127,9 +127,12 @@ export function ReviewSubmit({
 
   return (
     <Card>
-      <h3 className="mb-3 border-b border-border pb-2 text-lg text-text-heading">
+      <h3 className="mb-1 text-lg text-text-heading">
         {t("pr.reviewSubmitTitle")}
       </h3>
+      <p className="mb-3 border-b border-border pb-2 text-sm text-text-secondary">
+        #{matchedPr.number} {matchedPr.title}
+      </p>
 
       {/* Feedback messages */}
       {successMessage && (
@@ -178,7 +181,7 @@ export function ReviewSubmit({
           {t("pr.approve")}
         </Button>
         <Button
-          variant="destructive"
+          variant="ghost"
           disabled={submitting || !comment.trim()}
           onClick={() => {
             clearMessages();


### PR DESCRIPTION
## Summary

Implements issue #458: ReviewSubmit: UIUX改善

## UIUXデザイナーレビュー指摘

### ① 「Approve」と「Request Changes」ボタンが同じ視覚的重みで並んでいる
どちらもPrimaryボタン相当に見えるが、Approveは推奨アクション、Request Changesは代替アクション。後者はSecondaryスタイル（アウトライン）にして主従関係を示すべき。

### ② ボタンがタイトル直下に孤立しており、操作前の確認コンテキストがない
「レビュー送信」というタイトルのみで、「どのPRに対するレビューか」が示されていない。PRタイトルや番号をサブテキストとして表示すると誤操作を防げる。

Closes #458

---
Generated by agent/loop.sh