### PR TITLE
fix: split判定基準を緩和し実装タイムアウトを30分に延長

### DIFF
--- a/agent/lib/00_config.sh
+++ b/agent/lib/00_config.sh
@@ -22,7 +22,7 @@ ALLOWED_ISSUE_AUTHOR="${ALLOWED_ISSUE_AUTHOR:-xiangma9712}"  # only process issu
 
 # ── Timeout settings for run_claude (seconds) ──────────────────────────────
 # Process-level timeout via `timeout` command. Exit code 124 = hung/killed.
-TIMEOUT_IMPLEMENT="${TIMEOUT_IMPLEMENT:-900}"       # 15min for implementation
+TIMEOUT_IMPLEMENT="${TIMEOUT_IMPLEMENT:-1800}"      # 30min for implementation
 TIMEOUT_VERIFY_FIX="${TIMEOUT_VERIFY_FIX:-300}"     # 5min for verify/review/CI fix
 
 # ── Iteration log settings ──────────────────────────────────────────────────

--- a/agent/prompts/roadmap.md
+++ b/agent/prompts/roadmap.md
@@ -38,7 +38,7 @@ For each new GitHub Issue:
    - **middle** — Core feature requests, important improvements
    - **low** — Nice-to-haves, minor enhancements
 4. Write a brief implementation approach (2-3 sentences)
-5. If the issue is too large (scope > 1 module or > ~200 lines), note that it should be split
+5. Only mark `needs_split: true` if the issue is clearly too large for a single agent run — e.g., spans 4+ unrelated modules, requires 500+ lines of new code, or involves multiple independent features. Most issues (even those touching 2-3 files like component + stories + tests) should NOT be split.
 
 ## Priority Guidelines
 


### PR DESCRIPTION
## Summary

- トリアージの `needs_split` 判定基準を緩和（1モジュール超 → 4+モジュール/500行超/複数独立機能）
- 実装タイムアウトを15分→30分に延長

## 背景

トリアージで「1モジュール超え or 200行超え」の基準が厳しすぎ、フロントエンドの変更（コンポーネント + Stories + VRT + i18n）がほぼ全てsplit対象になっていた。43件のissueが不正にsplit→クローズされた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)