### PR TITLE
fix: 認証エラー検知とイテレーションログの保持問題を修正

### DIFF
--- a/agent/loop.sh
+++ b/agent/loop.sh
@@ -83,6 +83,8 @@ for f in "$SCRIPT_DIR"/lib/*.sh; do safe_source "$f"; done
 # Clear rate limit flag from previous runs
 rm -f "$RATE_LIMIT_FLAG"
 mkdir -p /tmp/claude
+# Clear stale iteration logs from previous runs (avoids name collision with iter-001, etc.)
+rm -rf "${AGENT_LOG_BASE:-/tmp/claude/agent-logs}"
 mkdir -p "${AGENT_LOG_BASE:-/tmp/claude/agent-logs}"
 
 # Ensure required labels exist on the repo


### PR DESCRIPTION
## Summary

- `run_claude` で OAuth トークン期限切れ（401）を検知してループを即座に停止
- エラー時に stderr だけでなく stdout もログに出力（claude CLI は認証エラーを stdout に出す）
- ループ起動時に前回のイテレーションログディレクトリを全クリアし、名前衝突（iter-001 が iter-050 より古いと判定されて即削除）を防止

## 背景

agent loop が全ステップで exit code 1 で即座に失敗していた。原因は OAuth トークン期限切れで `claude -p` が 401 を返していたが、エラーメッセージが stdout に出力されるため stderr ベースの検出では捕捉できなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)