### PR TITLE
fix: フロントエンド変更時のVRTスナップショット更新漏れ対策

### DIFF
--- a/agent/prompts/implement.md
+++ b/agent/prompts/implement.md
@@ -26,6 +26,14 @@ Implement exactly **one task** from a GitHub issue.
 - **Minimal changes** — don't refactor unrelated code
 - **No secrets** — never commit tokens, keys, or credentials
 
+## Frontend Changes
+
+フロントエンドコンポーネント (`frontend/src/components/*.tsx`) を変更・追加した場合、以下を必ず実施すること:
+
+- 対応する Stories ファイル (`*.stories.tsx`) を更新・追加する
+- VRT スナップショットを更新する: `cd frontend && npx playwright test --update-snapshots`
+- アニメーション系テスト（Loading, Spinner等）には `maxDiffPixelRatio: 0.08` を設定する
+
 ## Commit
 
 When done, stage and commit your changes with a conventional commit message.

--- a/agent/steps/05_verify.sh
+++ b/agent/steps/05_verify.sh
@@ -73,6 +73,13 @@ step_verify() {
     fi
 
     log "WARN: Working tree not clean (attempt $verify_attempt). Committing remaining changes..."
+
+    # If frontend component files were changed, update VRT snapshots before committing
+    if git diff --name-only HEAD | grep -q 'frontend/src/components/.*\.tsx$' 2>/dev/null; then
+      log "Frontend components changed — updating VRT snapshots..."
+      (cd "$REPO_ROOT/frontend" && npx playwright test --update-snapshots 2>/dev/null) || true
+    fi
+
     git add -A
 
     # Try commit — capture hook errors if it fails


### PR DESCRIPTION
Closes #512

## Summary
- `agent/prompts/implement.md` にフロントエンド変更時のStories/VRTスナップショット更新ルールを追加
- `agent/steps/05_verify.sh` でコンポーネント変更を検知した場合、コミット前に `npx playwright test --update-snapshots` を自動実行

## Test plan
- [ ] フロントエンドコンポーネント変更時にVRTスナップショットが自動更新されることを確認
- [ ] 実装エージェントがStories/VRT更新を実施することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)