### PR TITLE
fix: Tauri コマンドから token パラメータを削除し Keychain から自動取得する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,16 +59,9 @@ export function App() {
     (async () => {
       setLoadingPrs(true);
       try {
-        const config = await invoke("load_app_config");
-        if (cancelled) return;
-        if (!config.github_token) {
-          setPrs([]);
-          return;
-        }
         const result = await invoke("list_pull_requests", {
           owner,
           repo,
-          token: config.github_token,
         });
         if (!cancelled) {
           setPrs(result);

--- a/frontend/src/components/AutomationPanel.stories.tsx
+++ b/frontend/src/components/AutomationPanel.stories.tsx
@@ -8,7 +8,6 @@ const meta = {
   args: {
     owner: "example",
     repo: "reown",
-    token: "ghp_dummy",
   },
   decorators: [
     (Story) => {

--- a/frontend/src/components/AutomationPanel.tsx
+++ b/frontend/src/components/AutomationPanel.tsx
@@ -18,10 +18,9 @@ type Phase = "idle" | "evaluating" | "confirm" | "executing" | "done";
 interface AutomationPanelProps {
   owner: string;
   repo: string;
-  token: string;
 }
 
-export function AutomationPanel({ owner, repo, token }: AutomationPanelProps) {
+export function AutomationPanel({ owner, repo }: AutomationPanelProps) {
   const { t } = useTranslation();
   const [phase, setPhase] = useState<Phase>("idle");
   const [candidates, setCandidates] = useState<AutoApproveCandidate[]>([]);
@@ -47,7 +46,6 @@ export function AutomationPanel({ owner, repo, token }: AutomationPanelProps) {
       const result = await invoke("evaluate_auto_approve_candidates", {
         owner,
         repo,
-        token,
       });
       setCandidates(result);
       if (result.length === 0) {
@@ -59,7 +57,7 @@ export function AutomationPanel({ owner, repo, token }: AutomationPanelProps) {
       setError(String(err));
       setPhase("idle");
     }
-  }, [owner, repo, token]);
+  }, [owner, repo]);
 
   const handleExecute = useCallback(async () => {
     if (!automationConfig || candidates.length === 0) return;
@@ -69,7 +67,6 @@ export function AutomationPanel({ owner, repo, token }: AutomationPanelProps) {
       const result = await invoke("run_auto_approve_with_merge", {
         owner,
         repo,
-        token,
         candidates,
         automationConfig,
       });
@@ -79,7 +76,7 @@ export function AutomationPanel({ owner, repo, token }: AutomationPanelProps) {
       setError(String(err));
       setPhase("done");
     }
-  }, [owner, repo, token, candidates, automationConfig]);
+  }, [owner, repo, candidates, automationConfig]);
 
   const approvedCount = outcomes.filter((o) => o.approve_success).length;
   const failedCount = outcomes.filter((o) => !o.approve_success).length;

--- a/frontend/src/components/ChangeSummaryList.stories.tsx
+++ b/frontend/src/components/ChangeSummaryList.stories.tsx
@@ -16,7 +16,6 @@ const meta = {
     owner: "example",
     repo: "reown",
     prNumber: 42,
-    token: "ghp_dummy",
     diffs: fixtures.categorizedFileDiffs,
   },
   decorators: [

--- a/frontend/src/components/ChangeSummaryList.tsx
+++ b/frontend/src/components/ChangeSummaryList.tsx
@@ -117,7 +117,6 @@ interface ChangeSummaryListProps {
   owner: string;
   repo: string;
   prNumber: number;
-  token: string;
   diffs: CategorizedFileDiff[];
   autoGenerate?: boolean;
 }
@@ -206,7 +205,6 @@ export function ChangeSummaryList({
   owner,
   repo,
   prNumber,
-  token,
   diffs,
   autoGenerate = false,
 }: ChangeSummaryListProps) {
@@ -285,7 +283,6 @@ export function ChangeSummaryList({
       owner: owner.trim(),
       repo: repo.trim(),
       prNumber,
-      token: token.trim(),
     };
 
     try {
@@ -306,7 +303,7 @@ export function ChangeSummaryList({
         unlistenRef.current = null;
       }
     }
-  }, [owner, repo, prNumber, token]);
+  }, [owner, repo, prNumber]);
 
   // Auto-generate summary when LLM is configured
   useEffect(() => {

--- a/frontend/src/components/ConsistencyCheckPanel.stories.tsx
+++ b/frontend/src/components/ConsistencyCheckPanel.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
     owner: "example",
     repo: "reown",
     prNumber: 42,
-    token: "ghp_dummy",
   },
   decorators: [
     (Story) => {

--- a/frontend/src/components/ConsistencyCheckPanel.tsx
+++ b/frontend/src/components/ConsistencyCheckPanel.tsx
@@ -10,14 +10,12 @@ interface ConsistencyCheckPanelProps {
   owner: string;
   repo: string;
   prNumber: number;
-  token: string;
 }
 
 export function ConsistencyCheckPanel({
   owner,
   repo,
   prNumber,
-  token,
 }: ConsistencyCheckPanelProps) {
   const { t } = useTranslation();
   const [consistency, setConsistency] = useState<ConsistencyResult | null>(
@@ -42,7 +40,6 @@ export function ConsistencyCheckPanel({
         owner: owner.trim(),
         repo: repo.trim(),
         prNumber,
-        token: token.trim(),
       });
       setConsistency(result);
     } catch (err) {
@@ -50,7 +47,7 @@ export function ConsistencyCheckPanel({
     } finally {
       setLoading(false);
     }
-  }, [owner, repo, prNumber, token]);
+  }, [owner, repo, prNumber]);
 
   return (
     <Card className="mt-4 space-y-3">

--- a/frontend/src/components/PrListView.stories.tsx
+++ b/frontend/src/components/PrListView.stories.tsx
@@ -81,7 +81,6 @@ export const WithExpandedCommits: Story = {
     prs: allPrs,
     owner: "example",
     repo: "reown",
-    token: "dummy-token",
   },
 };
 
@@ -91,7 +90,6 @@ export const WithExpandedCommitsError: Story = {
     prs: allPrs,
     owner: "example",
     repo: "reown",
-    token: "dummy-token",
   },
   beforeEach: () => {
     overrideInvoke({

--- a/frontend/src/components/PrListView.tsx
+++ b/frontend/src/components/PrListView.tsx
@@ -17,7 +17,6 @@ interface PrListViewProps {
   riskLevels?: Record<number, RiskLevel>;
   owner?: string;
   repo?: string;
-  token?: string;
   onSelectPr?: (pr: PrInfo) => void;
 }
 
@@ -88,7 +87,6 @@ export function PrListView({
   riskLevels = {},
   owner,
   repo,
-  token,
   onSelectPr,
 }: PrListViewProps) {
   const { t } = useTranslation();
@@ -119,7 +117,7 @@ export function PrListView({
 
       setExpandedPr(pr.number);
 
-      if (!owner || !repo || !token) return;
+      if (!owner || !repo) return;
 
       setCommitsLoading(true);
       setCommitsError(null);
@@ -129,7 +127,6 @@ export function PrListView({
           owner,
           repo,
           prNumber: pr.number,
-          token,
         });
         setCommits(result);
       } catch (err) {
@@ -138,7 +135,7 @@ export function PrListView({
         setCommitsLoading(false);
       }
     },
-    [owner, repo, token, expandedPr, onSelectPr]
+    [owner, repo, expandedPr, onSelectPr]
   );
 
   return (

--- a/frontend/src/components/PrSummaryPanel.stories.tsx
+++ b/frontend/src/components/PrSummaryPanel.stories.tsx
@@ -16,7 +16,6 @@ const meta = {
     owner: "example",
     repo: "reown",
     prNumber: 42,
-    token: "ghp_dummy",
   },
   decorators: [
     (Story) => {

--- a/frontend/src/components/PrSummaryPanel.tsx
+++ b/frontend/src/components/PrSummaryPanel.tsx
@@ -11,15 +11,9 @@ interface PrSummaryPanelProps {
   owner: string;
   repo: string;
   prNumber: number;
-  token: string;
 }
 
-export function PrSummaryPanel({
-  owner,
-  repo,
-  prNumber,
-  token,
-}: PrSummaryPanelProps) {
+export function PrSummaryPanel({ owner, repo, prNumber }: PrSummaryPanelProps) {
   const { t } = useTranslation();
   const [summary, setSummary] = useState<PrSummary | null>(null);
   const [loading, setLoading] = useState(false);
@@ -83,7 +77,6 @@ export function PrSummaryPanel({
         owner: owner.trim(),
         repo: repo.trim(),
         prNumber,
-        token: token.trim(),
       });
       if (cancelledRef.current) return;
       setSummary(result);
@@ -101,7 +94,7 @@ export function PrSummaryPanel({
         unlistenRef.current = null;
       }
     }
-  }, [owner, repo, prNumber, token]);
+  }, [owner, repo, prNumber]);
 
   return (
     <Card className="space-y-3">

--- a/frontend/src/components/ReviewSubmit.stories.tsx
+++ b/frontend/src/components/ReviewSubmit.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
     matchedPr: fixtures.pullRequests[0],
     owner: "example",
     repo: "reown",
-    token: "ghp_dummy",
     analysisResult: fixtures.analysisResult,
     prDiffs: fixtures.categorizedFileDiffs,
   },

--- a/frontend/src/components/ReviewSubmit.tsx
+++ b/frontend/src/components/ReviewSubmit.tsx
@@ -15,7 +15,6 @@ interface ReviewSubmitProps {
   matchedPr: PrInfo;
   owner: string;
   repo: string;
-  token: string;
   analysisResult: AnalysisResult | null;
   prDiffs: CategorizedFileDiff[];
   comment?: string;
@@ -26,7 +25,6 @@ export function ReviewSubmit({
   matchedPr,
   owner,
   repo,
-  token,
   analysisResult,
   prDiffs,
   comment: externalComment,
@@ -81,7 +79,6 @@ export function ReviewSubmit({
           prNumber: matchedPr.number,
           event,
           body: comment,
-          token,
         });
 
         // Record to review history
@@ -116,7 +113,6 @@ export function ReviewSubmit({
       owner,
       repo,
       matchedPr.number,
-      token,
       prDiffs,
       analysisResult,
       t,

--- a/frontend/src/components/ReviewSuggestionPanel.stories.tsx
+++ b/frontend/src/components/ReviewSuggestionPanel.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
     owner: "example",
     repo: "reown",
     prNumber: 42,
-    token: "ghp_dummy",
   },
   decorators: [
     (Story) => {

--- a/frontend/src/components/ReviewSuggestionPanel.tsx
+++ b/frontend/src/components/ReviewSuggestionPanel.tsx
@@ -11,7 +11,6 @@ interface ReviewSuggestionPanelProps {
   owner: string;
   repo: string;
   prNumber: number;
-  token: string;
   onInsertComment?: (text: string) => void;
 }
 
@@ -34,7 +33,6 @@ export function ReviewSuggestionPanel({
   owner,
   repo,
   prNumber,
-  token,
   onInsertComment,
 }: ReviewSuggestionPanelProps) {
   const { t } = useTranslation();
@@ -61,7 +59,6 @@ export function ReviewSuggestionPanel({
         owner: owner.trim(),
         repo: repo.trim(),
         prNumber,
-        token: token.trim(),
       });
       setSuggestions(result);
     } catch (err) {
@@ -69,7 +66,7 @@ export function ReviewSuggestionPanel({
     } finally {
       setLoading(false);
     }
-  }, [owner, repo, prNumber, token]);
+  }, [owner, repo, prNumber]);
 
   return (
     <Card className="mt-4 space-y-3">

--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -49,15 +49,15 @@ export type Commands = {
     ret: FileDiff[];
   };
   list_pull_requests: {
-    args: { owner: string; repo: string; token: string };
+    args: { owner: string; repo: string };
     ret: PrInfo[];
   };
   get_pull_request_files: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: CategorizedFileDiff[];
   };
   list_pr_commits: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: CommitInfo[];
   };
   submit_pr_review: {
@@ -67,7 +67,6 @@ export type Commands = {
       prNumber: number;
       event: ReviewEvent;
       body: string;
-      token: string;
     };
     ret: void;
   };
@@ -90,11 +89,11 @@ export type Commands = {
   };
   load_app_config: { args?: Record<string, unknown>; ret: AppConfig };
   summarize_pull_request: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: PrSummary;
   };
   check_pr_consistency: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: ConsistencyResult;
   };
   save_llm_config: {
@@ -112,11 +111,11 @@ export type Commands = {
     ret: void;
   };
   analyze_pr_risk: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: AnalysisResult;
   };
   analyze_pr_risk_with_llm: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: HybridAnalysisResult;
   };
   save_automation_config: {
@@ -144,14 +143,13 @@ export type Commands = {
     ret: void;
   };
   evaluate_auto_approve_candidates: {
-    args: { owner: string; repo: string; token: string };
+    args: { owner: string; repo: string };
     ret: AutoApproveCandidate[];
   };
   run_auto_approve_with_merge: {
     args: {
       owner: string;
       repo: string;
-      token: string;
       candidates: AutoApproveCandidate[];
       automationConfig: AutomationConfig;
     };
@@ -163,7 +161,7 @@ export type Commands = {
     ret: WorktreeInfo;
   };
   suggest_review_comments: {
-    args: { owner: string; repo: string; prNumber: number; token: string };
+    args: { owner: string; repo: string; prNumber: number };
     ret: ReviewSuggestion[];
   };
   list_review_history: { args?: Record<string, unknown>; ret: ReviewRecord[] };


### PR DESCRIPTION
## Summary

Implements issue #509: Tauri コマンドから token パラメータを削除し Keychain から自動取得する

## 概要

`app/src/main.rs` の GitHub 系 Tauri コマンドから `token: String` パラメータを削除し、各コマンド内で `load_github_token()` を呼び出してトークンを自動取得するように変更する。

## やること

以下の Tauri コマンドから `token: String` パラメータを削除し、内部で `load_github_token()` を呼び出す:

- `list_pull_requests`
- `get_pull_request_files`
- `list_pr_commits`
- `submit_pr_review`
- `enable_pr_auto_merge`
- `analyze_pr_risk`
- `analyze_pr_risk_with_llm`
- `summarize_pull_request`
- `check_pr_consistency`
- `evaluate_auto_approve_candidates`
- `run_auto_approve`
- `run_auto_approve_with_merge`
- `suggest_review_comments`

トークンが未設定の場合は「GitHub にログインしてください」等の適切なエラーメッセージを返す。

## 受け入れ基準

- [ ] 全 GitHub 系 Tauri コマンドが `token` パラメータなしのシグネチャになっている
- [ ] 各コマンド内で `load_github_token()` からトークンを取得している
- [ ] トークン未設定時に分かりやすいエラーが返される
- [ ] `cargo test` が通る
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #484

Closes #509

---
Generated by agent/loop.sh