### PR TITLE
feat: AppConfigにonboarding_completedフィールドを追加する

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -496,6 +496,31 @@ fn save_risk_config(
     reown::config::save_config(&config_path, &config).map_err(AppError::storage)
 }
 
+// ── Onboarding commands ──────────────────────────────────────────────────────
+
+#[tauri::command]
+fn check_onboarding_needed(app_handle: tauri::AppHandle) -> Result<bool, AppError> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::storage(anyhow::anyhow!("{e}")))?;
+    let config_path = reown::config::default_config_path(&app_data_dir);
+    let config = reown::config::load_config(&config_path).map_err(AppError::storage)?;
+    Ok(!config.onboarding_completed)
+}
+
+#[tauri::command]
+fn complete_onboarding(app_handle: tauri::AppHandle) -> Result<(), AppError> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::storage(anyhow::anyhow!("{e}")))?;
+    let config_path = reown::config::default_config_path(&app_data_dir);
+    let mut config = reown::config::load_config(&config_path).map_err(AppError::storage)?;
+    config.onboarding_completed = true;
+    reown::config::save_config(&config_path, &config).map_err(AppError::storage)
+}
+
 // ── Automation commands ───────────────────────────────────────────────────────
 
 #[tauri::command]
@@ -753,6 +778,8 @@ fn main() {
             suggest_review_comments,
             list_review_history,
             add_review_record,
+            check_onboarding_needed,
+            complete_onboarding,
             start_github_device_flow,
             poll_github_device_flow,
             get_github_auth_status,

--- a/frontend/src/storybook/fixtures.ts
+++ b/frontend/src/storybook/fixtures.ts
@@ -341,6 +341,7 @@ const appConfig: AppConfig = {
   default_repo: "reown",
   llm: llmConfig,
   automation: automationConfig,
+  onboarding_completed: false,
 };
 
 const prSummary: PrSummary = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -125,6 +125,7 @@ export interface AppConfig {
   default_repo: string;
   llm: LlmConfig;
   automation: AutomationConfig;
+  onboarding_completed: boolean;
 }
 
 export interface FileSummary {


### PR DESCRIPTION
## Summary

Implements issue #516: AppConfigにonboarding_completedフィールドを追加する

## 概要

`AppConfig` に `onboarding_completed: bool` フィールドを追加し、初回起動判定に必要なバックエンド基盤を整える。

## 受け入れ基準

- [ ] `lib/config.rs` の `AppConfig` に `onboarding_completed: bool` フィールドを追加する（`#[serde(default)]` でデフォルト `false`）
- [ ] `frontend/src/types.ts` の `AppConfig` インターフェースに `onboarding_completed: boolean` を追加する
- [ ] `frontend/src/storybook/fixtures.ts` の `appConfig` フィクスチャに `onboarding_completed` を追加する
- [ ] Tauri コマンド `check_onboarding_needed` を `app/src/main.rs` に追加する（`load_app_config` して `!onboarding_completed` を返す）
- [ ] Tauri コマンド `complete_onboarding` を `app/src/main.rs` に追加する（`onboarding_completed = true` を保存）
- [ ] `cargo test` と `cargo clippy --all-targets -- -D warnings` が通る

## 技術メモ

- 既存の `load_config` / `save_config` を利用する。新たなファイルI/Oは不要
- `#[serde(default)]` により、既存の config.json にフィールドがなくても `false` としてデシリアライズされる
- `check_onboarding_needed` は `bool` を返すシンプルなコマンド
- `complete_onboarding` は config をロードし、フィールドを `true` に設定して保存する

Parent: #488

Closes #516

---
Generated by agent/loop.sh