### PR TITLE
fix: self-review 成功後に失敗カウンタをリセットする

### DIFF
--- a/agent/lib/50_failure_tracking.sh
+++ b/agent/lib/50_failure_tracking.sh
@@ -29,6 +29,14 @@ should_create_review_issue() {
   [[ "$count" -ge 2 ]]
 }
 
+# Reset failure history (e.g. after successful self-review).
+reset_failure_history() {
+  if [[ -f "$ITERATION_RESULTS_FILE" ]]; then
+    log "Resetting failure history after successful self-review."
+    : > "$ITERATION_RESULTS_FILE"
+  fi
+}
+
 # True if 4+ failures in the last 5 iterations — exit loop.
 should_exit_on_failure_rate() {
   local count

--- a/agent/loop.sh
+++ b/agent/loop.sh
@@ -207,6 +207,10 @@ while true; do
       ;;
     next)
       record_iteration_result "success" "complete" "${TASK_ISSUE:-}"
+      # Reset failure history after successful self-review to prevent re-triggering
+      if [[ "$_is_review_iteration" == "true" ]]; then
+        reset_failure_history
+      fi
       ;;
   esac
 


### PR DESCRIPTION
## Summary

- self-review 成功後に `iteration-results.log` をクリアする `reset_failure_history()` を追加
- 古い fail 記録で self-review が繰り返しトリガーされるループを防止

Closes #545

## Test plan

- [ ] `bash -n` 構文チェック通過済み
- [ ] self-review 成功後に次のイテレーションで通常タスクが pick されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)