### PR TITLE
feat: config.json の github_token を Keychain へマイグレーションする処理を追加

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -735,6 +735,16 @@ fn add_review_record(
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .setup(|app| {
+            // config.json の github_token を Keychain にマイグレーション
+            if let Ok(app_data_dir) = app.path().app_data_dir() {
+                let config_path = reown::config::default_config_path(&app_data_dir);
+                if let Err(e) = reown::config::migrate_github_token_to_keychain(&config_path) {
+                    eprintln!("GitHubトークンのマイグレーションに失敗: {e:#}");
+                }
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             list_branches,
             list_enriched_branches,


### PR DESCRIPTION
## Summary

Implements issue #522: config.json の github_token を Keychain へマイグレーションする処理を追加

## 概要

既存ユーザーの `config.json` に保存されている `github_token` を Keychain に自動マイグレーションする処理を追加する。

## やること

### マイグレーション処理の実装
- アプリ起動時（または config 読み込み時）に `config.json` の `github_token` が存在するかチェック
- 存在する場合、`save_github_token()` で Keychain に保存
- 保存成功後、`config.json` から `github_token` フィールドを削除して保存し直す
- マイグレーション済みの場合はスキップ

### Rust 側 (`lib/config.rs` or `app/src/main.rs`)
- `migrate_github_token_to_keychain()` 関数を追加
- `AppConfig` 構造体から `github_token` フィールドを削除（または `Option<String>` に変更してデシリアライズ互換性を維持）
- アプリ初期化時にマイグレーション関数を呼び出す

### テスト
- `github_token` が config に存在する場合にマイグレーションされることをテスト
- `github_token` が config に存在しない場合に何も起きないことをテスト
- マイグレーション後に config から `github_token` が削除されていることをテスト

## 受け入れ基準

- [ ] 既存の `config.json` にトークンがある場合、Keychain に自動移行される
- [ ] マイグレーション後、`config.json` から `github_token` が削除される
- [ ] `github_token` がない config でもエラーにならない
- [ ] `cargo test` が通る
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #484

Closes #522

---
Generated by agent/loop.sh