### PR TITLE
fix: chore: agent loop 見直し（自動検出）

### DIFF
--- a/agent/lib/40_github.sh
+++ b/agent/lib/40_github.sh
@@ -131,13 +131,14 @@ $SRC_FILES
 \`\`\`"
 
   log "Running propose agent to identify unrealized features..."
-  PROPOSE_STDERR="/tmp/claude/agent-propose-stderr.log"
-  PROPOSE_OUTPUT=$(claude -p "$PROPOSE_INPUT" \
+  local propose_rc=0
+  PROPOSE_OUTPUT=$(run_claude \
+    --label "propose" \
+    --timeout "$TIMEOUT_TRIAGE" \
     --max-turns "$PROPOSE_MAX_TURNS" \
-    --max-budget-usd "$MAX_BUDGET_USD" \
-    2>"$PROPOSE_STDERR") || true
+    -- "$PROPOSE_INPUT") || propose_rc=$?
 
-  if check_rate_limit "$PROPOSE_STDERR"; then
+  if [[ "$propose_rc" -eq 2 ]]; then
     flag_rate_limit
     return 1
   fi

--- a/agent/steps/01_setup.sh
+++ b/agent/steps/01_setup.sh
@@ -26,6 +26,7 @@ step_setup() {
     log "No open issues with label '$AGENT_LABEL'. Proposing new issues from INTENT.md gap analysis..."
     if ! propose_issues; then return 2; fi
     if is_rate_limited; then return 2; fi
+    _skip_is_benign=true
     interruptible_sleep "$SLEEP_SECONDS"
     return 1
   fi

--- a/agent/steps/03_select.sh
+++ b/agent/steps/03_select.sh
@@ -25,6 +25,7 @@ step_select() {
     log "No planned tasks available. Proposing new issues from INTENT.md gap analysis..."
     if ! propose_issues; then return 2; fi
     if is_rate_limited; then return 2; fi
+    _skip_is_benign=true
     interruptible_sleep "$SLEEP_SECONDS"
     return 1
   fi

--- a/agent/steps/04_implement.sh
+++ b/agent/steps/04_implement.sh
@@ -67,6 +67,7 @@ _Automatically posted by agent/loop.sh_" 2>/dev/null || true
       gh issue close "$TASK_ISSUE" 2>/dev/null || true
       log "Issue #$TASK_ISSUE closed as already implemented (pre-check)."
       cleanup_branch "$BRANCH_NAME"
+      _skip_is_benign=true
       interruptible_sleep "$SLEEP_SECONDS"
       return 1
     fi
@@ -142,6 +143,7 @@ _Automatically posted by agent/loop.sh_" 2>/dev/null || true
     gh issue close "$TASK_ISSUE" 2>/dev/null || true
     log "Issue #$TASK_ISSUE closed as already implemented."
     cleanup_branch "$BRANCH_NAME"
+    _skip_is_benign=true
     interruptible_sleep "$SLEEP_SECONDS"
     return 1
   fi


### PR DESCRIPTION
## Summary

Implements issue #549: chore: agent loop 見直し（自動検出）

## Agent Loop 見直し

直近のイテレーションで失敗が頻発しています。失敗パターンを分析し、agent loop を修正してください。

## 失敗履歴

```
2026-02-28 15:56:17 fail step_implement 521
2026-02-28 16:08:19 success complete 522
2026-02-28 16:09:08 fail step_implement 533
```

## 直近のログ（progress.txt）

```
[2026-02-28 15:55:31] Running pre-implementation verification for #521...
[2026-02-28 15:55:31] run_claude [precheck-521] starting (timeout=300s, max-turns=10, budget=5)
[2026-02-28 15:56:06] run_claude [precheck-521] completed successfully
[2026-02-28 15:56:06] Pre-check passed: requirements already met for #521. Skipping implementation.
[2026-02-28 15:56:12] Issue #521 closed as already implemented (pre-check).
[2026-02-28 15:56:17] --- Iteration 2 ---
[2026-02-28 15:56:17] Iteration log directory: /tmp/claude/agent-logs/iter-002
[2026-02-28 15:56:17] Fetching latest from origin...
[2026-02-28 15:56:19] Fetched 50 open issues with label 'agent' (50 from allowed author 'xiangma9712')
[2026-02-28 15:56:19] Selected task: #522 — config.json の github_token を Keychain へマイグレーションする処理を追加
[2026-02-28 15:56:21] Running pre-implementation verification for #522...
[2026-02-28 15:56:21] run_claude [precheck-522] starting (timeout=300s, max-turns=10, budget=5)
[2026-02-28 15:57:24] run_claude [precheck-522] completed successfully
[2026-02-28 15:57:24] Pre-check: requirements not yet met for #522. Proceeding with implementation.
[2026-02-28 15:57:24] Running implementation agent for #522...
[2026-02-28 15:57:24] run_claude [implement-522] starting (timeout=1800s, max-turns=30, budget=5)
[2026-02-28 16:01:29] run_claude [implement-522] completed successfully
[2026-02-28 16:01:29] Running cargo fmt...
[2026-02-28 16:01:29] Rust files changed — running cargo test and clippy...
[2026-02-28 16:01:34] Verify passed: working tree is clean.
[2026-02-28 16:01:34] Running smart review agent for #522...
[2026-02-28 16:01:34] run_claude [review-522] starting (timeout=300s, max-turns=10, budget=5)
[2026-02-28 16:06:34] ERROR: run_claude [review-522] timed out after 300s (hung process killed)
[2026-02-28 16:06:34] WARN: Review agent failed (rc=124). Treating as pass.
[2026-02-28 16:06:35] Post-push verification passed: local and remote are in sync.
[2026-02-28 16:06:35] Detected commit prefix: feat
[2026-02-28 16:06:37] PR created: https://github.com/xiangma9712/reown/pull/548
[2026-02-28 16:06:38] Post-PR verification passed: PR contains changes in 2 file(s).
[2026-02-28 16:06:38] Waiting for CI checks (attempt 1/5)...
[2026-02-28 16:06:38] Waiting 60s for CI to start...
[2026-02-28 16:07:39] CI still running (poll 1, 0s elapsed)...
[2026-02-28 16:08:10] CI checks passed.
[2026-02-28 16:08:10] CI passed. Merging PR...
[2026-02-28 16:08:14] PR merged: https://github.com/xiangma9712/reown/pull/548
[2026-02-28 16:08:18] Issue #522 marked as done and closed
[2026-02-28 16:08:19] Task #522 completed successfully.
[2026-02-28 16:08:19] Sleeping 5s before next iteration...
[2026-02-28 16:08:24] --- Iteration 3 ---
[2026-02-28 16:08:24] Iteration log directory: /tmp/claude/agent-logs/iter-003
[2026-02-28 16:08:24] Fetching latest from origin...
[2026-02-28 16:08:26] Fetched 49 open issues with label 'agent' (49 from allowed author 'xiangma9712')
[2026-02-28 16:08:26] Selected task: #533 — fix: implement エージェントがコミット前にフォーマッタを実行するよう改善
[2026-02-28 16:08:28] Running pre-implementation verification for #533...
[2026-02-28 16:08:28] run_claude [precheck-533] starting (timeout=300s, max-turns=10, budget=5)
[2026-02-28 16:08:58] run_claude [precheck-533] completed successfully
[2026-02-28 16:08:58] Pre-check passed: requirements already met for #533. Skipping implementation.
[2026-02-28 16:09:03] Issue #533 closed as already implemented (pre-check).
[2026-02-28 16:09:08] --- Iteration 4 ---
[2026-02-28 16:09:08] Iteration log directory: /tmp/claude/agent-logs/iter-004
[2026-02-28 16:09:08] WARN: 過去5回のイテレーションで2回以上失敗。self-review issueを確認します。
```

## 調査手順

**ローカルのイテレーションログを必ず読んでください。** 失敗時のログは自動保持されています。

1. `/tmp/claude/agent-logs/` 配下のイテレーションログディレクトリ（`iter-NNN/`）を確認する
2. 各ディレクトリ内の `*.stdout.log` と `*.stderr.log` を読み、失敗の根本原因を特定する
3. `/tmp/claude/agent-logs/iteration-results.log` で失敗したステップと issue 番号を照合する
4. 根本原因に基づいて `agent/` 配下のファイルを修正する

## ルール

- **このissueでは `agent/` ファイルの修正が許可されています**（通常の implement.md の制約を上書き）
- `bash -n` で全修正ファイルの構文チェックを必ず実施してください
- テスト実行は不要です（agent/ はシェルスクリプトのため）

---
_Automatically created by agent failure tracking_

Closes #549

---
Generated by agent/loop.sh