### PR TITLE
fix: fix: risk_thresholds の low_max に負の値や medium_max 以上の値が入力可能

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -385,13 +385,19 @@ export function AutomationSettingsTab() {
                     onChange={(e) => {
                       const val = parseInt(e.target.value, 10);
                       if (!isNaN(val)) {
-                        setRiskConfig((prev) => ({
-                          ...prev,
-                          risk_thresholds: {
-                            ...prev.risk_thresholds,
-                            low_max: val,
-                          },
-                        }));
+                        setRiskConfig((prev) => {
+                          const clamped = Math.max(
+                            0,
+                            Math.min(val, prev.risk_thresholds.medium_max - 1)
+                          );
+                          return {
+                            ...prev,
+                            risk_thresholds: {
+                              ...prev.risk_thresholds,
+                              low_max: clamped,
+                            },
+                          };
+                        });
                       }
                     }}
                     className="w-20 rounded border border-border bg-bg-primary px-2 py-1 text-[0.8rem] text-text-primary"
@@ -410,13 +416,19 @@ export function AutomationSettingsTab() {
                     onChange={(e) => {
                       const val = parseInt(e.target.value, 10);
                       if (!isNaN(val)) {
-                        setRiskConfig((prev) => ({
-                          ...prev,
-                          risk_thresholds: {
-                            ...prev.risk_thresholds,
-                            medium_max: val,
-                          },
-                        }));
+                        setRiskConfig((prev) => {
+                          const clamped = Math.max(
+                            prev.risk_thresholds.low_max + 1,
+                            Math.min(val, 100)
+                          );
+                          return {
+                            ...prev,
+                            risk_thresholds: {
+                              ...prev.risk_thresholds,
+                              medium_max: clamped,
+                            },
+                          };
+                        });
                       }
                     }}
                     className="w-20 rounded border border-border bg-bg-primary px-2 py-1 text-[0.8rem] text-text-primary"


### PR DESCRIPTION
## Summary

Implements issue #590: fix: risk_thresholds の low_max に負の値や medium_max 以上の値が入力可能

frontend/src/components/AutomationSettingsTab.tsx:345-365 — number input の min/max 制約は HTML レベルでは強制されないため、ユーザーが直接値を入力した場合に low_max >= medium_max となる不整合な状態が発生しうる。onChange 内でのバリデーション追加を検討。

---
_レビューエージェントが #499 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #590

---
Generated by agent/loop.sh