### PR TITLE
refactor: refactor: GithubSettingsTab の token 保存を専用コマンドに移行

### DIFF
--- a/frontend/src/components/GithubSettingsTab.tsx
+++ b/frontend/src/components/GithubSettingsTab.tsx
@@ -44,10 +44,7 @@ export function GithubSettingsTab() {
       setSaving(true);
       setMessage(null);
 
-      const config = await invoke("load_app_config");
-      await invoke("save_app_config", {
-        config: { ...config },
-      });
+      await invoke("save_github_token", { token });
 
       setTokenStored(true);
       setToken("");


### PR DESCRIPTION
## Summary

Implements issue #534: refactor: GithubSettingsTab の token 保存を専用コマンドに移行

frontend/src/components/GithubSettingsTab.tsx:47-50 — save ハンドラが `load_app_config` → spread → `save_app_config` で `github_token` を渡しているが、TypeScript の `AppConfig` からは `github_token` が削除済み。logout 側と同様に `save_github_token` 専用コマンドを作成し、`save_app_config` 経由の token 保存を廃止することで型の整合性が向上する

---
_レビューエージェントが #510 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #534

---
Generated by agent/loop.sh