### PR TITLE
fix: fix: propose_issues の rate limit 時に return 2 ではなく return 1 を返している

### DIFF
--- a/agent/lib/40_github.sh
+++ b/agent/lib/40_github.sh
@@ -140,7 +140,7 @@ $SRC_FILES
 
   if [[ "$propose_rc" -eq 2 ]]; then
     flag_rate_limit
-    return 1
+    return 2
   fi
 
   PROPOSE_JSON=$(echo "$PROPOSE_OUTPUT" | sed -n '/^```json$/,/^```$/{ /^```/d; p; }')


### PR DESCRIPTION
## Summary

Implements issue #550: fix: propose_issues の rate limit 時に return 2 ではなく return 1 を返している

agent/lib/40_github.sh:143 — `run_claude` が rate limit で exit 2 を返した場合、`propose_issues` は `flag_rate_limit` してから `return 1` を返す。呼び出し元の `step_setup` (01_setup.sh:27) と `step_select` (03_select.sh:26) では `if ! propose_issues; then return 2; fi` としているため結果的に loop は break するが、`propose_issues` 自体の返り値セマンティクスが `run_claude` の convention (2=rate limit) と不一致。既存動作は壊れていないが、将来の保守性のために統一を検討すべき。

---
_レビューエージェントが #549 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #550

---
Generated by agent/loop.sh