### PR TITLE
refactor: refactor: CI fix プロンプトの `<run-id>` プレースホルダーを実際のコマンドチェーンに置き換える

### DIFF
--- a/agent/steps/07_ci.sh
+++ b/agent/steps/07_ci.sh
@@ -77,14 +77,10 @@ step_ci() {
 
 ## Step 1: Read the CI logs
 
-1. Get the latest failed run ID:
-   \`\`\`
-   gh run list --branch $BRANCH_NAME --limit 1 --json databaseId,status,conclusion --jq '.[0]'
-   \`\`\`
-2. View the failed logs:
-   \`\`\`
-   gh run view <run-id> --log-failed
-   \`\`\`
+Run this command to get the failed CI logs:
+\`\`\`
+gh run view \$(gh run list --branch $BRANCH_NAME --limit 1 --json databaseId --jq '.[0].databaseId') --log-failed
+\`\`\`
 
 ## Step 2: Fix the issues
 


### PR DESCRIPTION
## Summary

Implements issue #553: refactor: CI fix プロンプトの `<run-id>` プレースホルダーを実際のコマンドチェーンに置き換える

agent/steps/07_ci.sh:86-87 — プロンプト内で `gh run view <run-id> --log-failed` と書いているが、`<run-id>` はエージェントが Step 1 の出力から手動で取得する必要がある。パイプで繋げたワンライナー（例: `gh run view $(gh run list --branch ... --jq '.[0].databaseId') --log-failed`）にすると、エージェントの失敗率を下げられる可能性がある

---
_レビューエージェントが #537 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #553

---
Generated by agent/loop.sh