### PR TITLE
refactor: refactor: fallback commit で `git add -A` の使用を限定的にする

### DIFF
--- a/agent/steps/07_ci.sh
+++ b/agent/steps/07_ci.sh
@@ -97,7 +97,8 @@ After fixing, run the appropriate formatters:
 You MUST commit and push your changes. This is critical — without this step the fix has no effect.
 
 \`\`\`bash
-git add -A
+git add -u
+git add -- \$(git ls-files --others --exclude-standard | grep -E '\\.(rs|toml|lock|ts|tsx|js|jsx|json|css|html|md|sh|yaml|yml|svg|png)\$')
 git commit -m \"fix: address CI failures for #$TASK_ISSUE\"
 git push
 \`\`\`
@@ -124,7 +125,7 @@ Run \`git status\` to confirm the working tree is clean and all changes have bee
       cd "$REPO_ROOT"
       if ! git diff --quiet || ! git diff --cached --quiet || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
         log "WARN: CI fix agent left uncommitted changes. Committing..."
-        git add -A
+        git_add_safe
         if ! git commit -m "fix: address CI failures for #$TASK_ISSUE" 2>/dev/null; then
           # Pre-commit hook failed — run formatters and retry
           log "WARN: Commit failed (pre-commit hook). Re-running formatters..."
@@ -133,7 +134,7 @@ Run \`git status\` to confirm the working tree is clean and all changes have bee
             (cd "$REPO_ROOT/frontend" && npx prettier --write src/ 2>/dev/null) || true
             (cd "$REPO_ROOT/frontend" && npx eslint --fix src/ 2>/dev/null) || true
           fi
-          git add -A
+          git_add_safe
           git commit -m "fix: address CI failures for #$TASK_ISSUE" 2>/dev/null || true
         fi
       fi


### PR DESCRIPTION
## Summary

Implements issue #554: refactor: fallback commit で `git add -A` の使用を限定的にする

agent/steps/07_ci.sh:131,140 — fallback の commit/push 処理で `git add -A` を使っているが、意図しないファイル（一時ファイル等）が含まれるリスクがある。CI fix の文脈ではリスクは低いが、エージェントが作成した一時ファイルをステージングしないよう、将来的には変更されたファイルのみを add する方が安全

---
_レビューエージェントが #537 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #554

---
Generated by agent/loop.sh