### PR TITLE
feat: feat: WorktreeList のブランチクリックで ReviewTab に遷移する機能を接続

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ export function App() {
   const [repoInfo, setRepoInfo] = useState<RepoInfo | null>(null);
   const [prs, setPrs] = useState<PrInfo[]>([]);
   const [loadingPrs, setLoadingPrs] = useState(false);
+  const [navigateToBranch, setNavigateToBranch] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [addingRepo, setAddingRepo] = useState(false);
   const [addRepoError, setAddRepoError] = useState<string | null>(null);
@@ -136,6 +137,12 @@ export function App() {
     }
   }, [t]);
 
+  const handleNavigateToBranch = useCallback((branch: string) => {
+    setNavigateToBranch(branch);
+    setActiveTab("review");
+    setSettingsOpen(false);
+  }, []);
+
   const dismissAddRepoError = useCallback(() => {
     setAddRepoError(null);
     clearTimeout(addErrorTimerRef.current);
@@ -179,14 +186,17 @@ export function App() {
         case "r":
           setActiveTab("review");
           setSettingsOpen(false);
+          setNavigateToBranch(null);
           break;
         case "n":
           setActiveTab("next-action");
           setSettingsOpen(false);
+          setNavigateToBranch(null);
           break;
         case "a":
           setActiveTab("automate");
           setSettingsOpen(false);
+          setNavigateToBranch(null);
           break;
         case "s":
           setSettingsOpen((prev) => !prev);
@@ -194,6 +204,7 @@ export function App() {
         case "Tab":
           e.preventDefault();
           setSettingsOpen(false);
+          setNavigateToBranch(null);
           setActiveTab((prev) => {
             const ids = NAV_ITEMS.map((item) => item.id);
             const idx = ids.indexOf(prev);
@@ -243,6 +254,7 @@ export function App() {
           onSelectTab={(id) => {
             setActiveTab(id as TabName);
             setSettingsOpen(false);
+            setNavigateToBranch(null);
           }}
           settingsOpen={settingsOpen}
           onToggleSettings={() => setSettingsOpen((prev) => !prev)}
@@ -255,9 +267,15 @@ export function App() {
           }
         >
           {activeTab === "review" && (
-            <ReviewTab prs={prs} loadingPrs={loadingPrs} />
+            <ReviewTab
+              prs={prs}
+              loadingPrs={loadingPrs}
+              navigateToBranch={navigateToBranch}
+            />
           )}
-          {activeTab === "next-action" && <TodoTab />}
+          {activeTab === "next-action" && (
+            <TodoTab onNavigateToBranch={handleNavigateToBranch} />
+          )}
           {activeTab === "automate" && <AutomationSettingsTab />}
         </Layout>
       </RepositoryProvider>

--- a/frontend/src/components/ReviewTab.tsx
+++ b/frontend/src/components/ReviewTab.tsx
@@ -236,9 +236,14 @@ function CollapseToggleButton({
 interface ReviewTabProps {
   prs?: PrInfo[];
   loadingPrs?: boolean;
+  navigateToBranch?: string | null;
 }
 
-export function ReviewTab({ prs = [], loadingPrs = false }: ReviewTabProps) {
+export function ReviewTab({
+  prs = [],
+  loadingPrs = false,
+  navigateToBranch,
+}: ReviewTabProps) {
   const { t } = useTranslation();
   const { repoPath, repoInfo } = useRepository();
   const {
@@ -249,6 +254,14 @@ export function ReviewTab({ prs = [], loadingPrs = false }: ReviewTabProps) {
     handleResizeStart: handleFileListResizeStart,
   } = useFileListPanel();
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
+
+  // Accept external branch navigation requests
+  useEffect(() => {
+    if (navigateToBranch) {
+      setSelectedBranch(navigateToBranch);
+    }
+  }, [navigateToBranch]);
+
   const [diffs, setDiffs] = useState<FileDiff[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/TodoTab.tsx
+++ b/frontend/src/components/TodoTab.tsx
@@ -73,7 +73,11 @@ function groupByModule(items: TodoItem[]): TodoGroup[] {
   return groups;
 }
 
-export function TodoTab() {
+interface TodoTabProps {
+  onNavigateToBranch?: (branch: string) => void;
+}
+
+export function TodoTab({ onNavigateToBranch }: TodoTabProps) {
   const { t } = useTranslation();
   const { repoPath } = useRepository();
   const [todos, setTodos] = useState<TodoItem[]>([]);
@@ -177,7 +181,7 @@ export function TodoTab() {
 
   return (
     <div className="space-y-6">
-      <WorktreeList />
+      <WorktreeList onNavigateToBranch={onNavigateToBranch} />
       <Card className="flex flex-col">
         <h2 className="mb-4 border-b border-border pb-2 text-lg text-text-heading">
           {t("todo.title")}


### PR DESCRIPTION
## Summary

Implements issue #558: feat: WorktreeList のブランチクリックで ReviewTab に遷移する機能を接続

frontend/src/components/TodoTab.tsx:180 — WorktreeList を onNavigateToBranch なしで使用している。Issue #431 の要件「ワークツリーのブランチをクリックすると ReviewTab でそのブランチのレビューに切り替わる」を満たすには、TodoTab → App のタブ切替コールバックを接続する必要がある。コンポーネント側は対応済みだが、配線が未接続。

---
_レビューエージェントが #431 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #558

---
Generated by agent/loop.sh