### PR TITLE
fix: fix: errorMessage の表示もハードコード色から CSS 変数に統一する

### DIFF
--- a/frontend/src/components/ReviewSubmit.tsx
+++ b/frontend/src/components/ReviewSubmit.tsx
@@ -137,7 +137,7 @@ export function ReviewSubmit({
         </div>
       )}
       {errorMessage && (
-        <div className="mb-3 rounded bg-red-100 px-3 py-2 text-sm text-red-800 dark:bg-red-900/30 dark:text-red-300">
+        <div className="mb-3 rounded border border-danger-border bg-danger-bg px-3 py-2 text-sm text-danger">
           {errorMessage}
         </div>
       )}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -20,6 +20,8 @@
   --color-success: #15803d;
   --color-success-bg: #f0fdf4;
   --color-success-border: #86efac;
+  --color-danger-bg: #fef2f2;
+  --color-danger-border: #fca5a5;
   --color-btn-secondary: #e5e7eb;
   --color-btn-secondary-hover: #d1d5db;
   --color-bg-hint: #f3f4f6;
@@ -59,6 +61,8 @@ html.dark {
   --color-success: #4ade80;
   --color-success-bg: rgba(22, 163, 74, 0.15);
   --color-success-border: rgba(22, 163, 74, 0.4);
+  --color-danger-bg: rgba(220, 38, 38, 0.15);
+  --color-danger-border: rgba(220, 38, 38, 0.4);
   --color-btn-secondary: #374151;
   --color-btn-secondary-hover: #4b5563;
   --color-bg-hint: #1f2937;


### PR DESCRIPTION
## Summary

Implements issue #567: fix: errorMessage の表示もハードコード色から CSS 変数に統一する

frontend/src/components/ReviewSubmit.tsx:140 — `successMessage` は CSS 変数に移行済みだが、`errorMessage` の表示は `bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300` のままハードコードされている。danger 系の CSS 変数（`--color-danger` 等）に統一すべき。

---
_レビューエージェントが #466 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #567

---
Generated by agent/loop.sh