### PR TITLE
fix: refactor: save_github_token に空文字列バリデーション追加を検討

### DIFF
--- a/lib/config.rs
+++ b/lib/config.rs
@@ -427,6 +427,9 @@ pub fn delete_llm_api_key() -> Result<()> {
 
 /// GitHubトークンをOS keychainに保存する
 pub fn save_github_token(token: &str) -> Result<()> {
+    if token.trim().is_empty() {
+        anyhow::bail!("GitHubトークンが空です");
+    }
     let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_GITHUB_TOKEN)
         .context("keychainエントリの作成に失敗")?;
     entry
@@ -1217,5 +1220,19 @@ mod tests {
         delete_github_token().unwrap();
         let result = load_github_token();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_github_token_rejects_empty() {
+        let result = save_github_token("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("空"));
+    }
+
+    #[test]
+    fn test_save_github_token_rejects_whitespace_only() {
+        let result = save_github_token("   ");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("空"));
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #583: refactor: save_github_token に空文字列バリデーション追加を検討

app/src/main.rs:640 — save_github_token は空文字列でも受け付ける。空トークンの保存を防ぐバリデーションの追加を検討すべき

---
_レビューエージェントが #490 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #583

---
Generated by agent/loop.sh