### PR TITLE
fix: fix: スコア入力値の範囲をクランプする

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -562,7 +562,8 @@ export function AutomationSettingsTab() {
                   value={newScore}
                   onChange={(e) => {
                     const val = parseInt(e.target.value, 10);
-                    if (!isNaN(val)) setNewScore(val);
+                    if (!isNaN(val))
+                      setNewScore(Math.max(0, Math.min(100, val)));
                   }}
                   className="w-16 rounded border border-border bg-bg-primary px-2 py-1 text-[0.8rem] text-text-primary"
                   aria-label={t("automation.sensitiveScore")}


### PR DESCRIPTION
## Summary

Implements issue #593: fix: スコア入力値の範囲をクランプする

frontend/src/components/AutomationSettingsTab.tsx:503-505 — `type="number"` に `min="0"` `max="100"` を設定しているが、onChange で値のクランプを行っていないため、手入力で 0-100 の範囲外の値を設定可能。`Math.max(0, Math.min(100, val))` でクランプすべき。

---
_レビューエージェントが #500 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #593

---
Generated by agent/loop.sh