### PR TITLE
fix: fix: 重複パターンの追加を防止する

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -136,6 +136,8 @@ export function AutomationSettingsTab() {
   const handleAddPattern = useCallback(() => {
     const trimmed = newPattern.trim();
     if (!trimmed) return;
+    if (riskConfig.sensitive_patterns.some((sp) => sp.pattern === trimmed))
+      return;
     setRiskConfig((prev) => ({
       ...prev,
       sensitive_patterns: [
@@ -145,7 +147,7 @@ export function AutomationSettingsTab() {
     }));
     setNewPattern("");
     setNewScore(15);
-  }, [newPattern, newScore]);
+  }, [newPattern, newScore, riskConfig.sensitive_patterns]);
 
   const handleRemovePattern = useCallback((index: number) => {
     setRiskConfig((prev) => ({
@@ -572,7 +574,12 @@ export function AutomationSettingsTab() {
                   variant="secondary"
                   size="sm"
                   onClick={handleAddPattern}
-                  disabled={!newPattern.trim()}
+                  disabled={
+                    !newPattern.trim() ||
+                    riskConfig.sensitive_patterns.some(
+                      (sp) => sp.pattern === newPattern.trim()
+                    )
+                  }
                 >
                   {t("automation.addPattern")}
                 </Button>


### PR DESCRIPTION
## Summary

Implements issue #594: fix: 重複パターンの追加を防止する

frontend/src/components/AutomationSettingsTab.tsx:133-143 — handleAddPattern で同じパターン文字列が既に存在するかチェックしていないため、重複パターンを追加できてしまう。追加前に `sensitive_patterns.some(sp => sp.pattern === trimmed)` でチェックを入れるとよい。

---
_レビューエージェントが #500 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #594

---
Generated by agent/loop.sh