### PR TITLE
test: test: SetupWizard のユニットテストを追加する

### DIFF
--- a/frontend/src/components/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { SetupWizard } from "./SetupWizard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "onboarding.step1Title": "リポジトリ選択",
+        "onboarding.step1Description":
+          "レビュー対象のリポジトリを選択してください。",
+        "onboarding.step2Title": "GitHub認証",
+        "onboarding.step2Description": "GitHubと連携します。",
+        "onboarding.step3Title": "LLM設定",
+        "onboarding.step3Description": "APIキーを設定します。",
+        "onboarding.completeTitle": "セットアップ完了！",
+        "onboarding.completeDescription": "reownの設定が完了しました。",
+        "onboarding.completeButton": "はじめる",
+        "onboarding.back": "戻る",
+        "onboarding.next": "次へ",
+        "onboarding.skip": "スキップ",
+      };
+      if (key === "onboarding.stepIndicator" && params) {
+        return `ステップ ${params.current} / ${params.total}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe("SetupWizard", () => {
+  it("renders step 1 (repository) by default", () => {
+    render(<SetupWizard onComplete={vi.fn()} />);
+    expect(
+      screen.getByRole("heading", { name: "リポジトリ選択" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ステップ 1 / 4")).toBeInTheDocument();
+  });
+
+  it("shows next and skip buttons on step 1, but not back", () => {
+    render(<SetupWizard onComplete={vi.fn()} />);
+    expect(screen.getByText("次へ")).toBeInTheDocument();
+    expect(screen.getByText("スキップ")).toBeInTheDocument();
+    expect(screen.queryByText("戻る")).not.toBeInTheDocument();
+  });
+
+  it("navigates to step 2 when next is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("次へ"));
+    expect(
+      screen.getByRole("heading", { name: "GitHub認証" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ステップ 2 / 4")).toBeInTheDocument();
+  });
+
+  it("shows back button on step 2", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("次へ"));
+    expect(screen.getByText("戻る")).toBeInTheDocument();
+  });
+
+  it("navigates back from step 2 to step 1", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("次へ"));
+    expect(
+      screen.getByRole("heading", { name: "GitHub認証" })
+    ).toBeInTheDocument();
+    await user.click(screen.getByText("戻る"));
+    expect(
+      screen.getByRole("heading", { name: "リポジトリ選択" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ステップ 1 / 4")).toBeInTheDocument();
+  });
+
+  it("navigates to step 3 via skip", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("スキップ"));
+    expect(
+      screen.getByRole("heading", { name: "GitHub認証" })
+    ).toBeInTheDocument();
+    await user.click(screen.getByText("スキップ"));
+    expect(
+      screen.getByRole("heading", { name: "LLM設定" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ステップ 3 / 4")).toBeInTheDocument();
+  });
+
+  it("navigates through all steps to complete", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    // Step 1 -> 2
+    await user.click(screen.getByText("次へ"));
+    expect(
+      screen.getByRole("heading", { name: "GitHub認証" })
+    ).toBeInTheDocument();
+    // Step 2 -> 3
+    await user.click(screen.getByText("次へ"));
+    expect(
+      screen.getByRole("heading", { name: "LLM設定" })
+    ).toBeInTheDocument();
+    // Step 3 -> complete
+    await user.click(screen.getByText("次へ"));
+    expect(
+      screen.getByRole("heading", { name: "セットアップ完了！" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ステップ 4 / 4")).toBeInTheDocument();
+  });
+
+  it("shows complete button on final step instead of next/skip", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    // Navigate to complete step
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    expect(screen.getByText("はじめる")).toBeInTheDocument();
+    expect(screen.queryByText("次へ")).not.toBeInTheDocument();
+    expect(screen.queryByText("スキップ")).not.toBeInTheDocument();
+    expect(screen.queryByText("戻る")).not.toBeInTheDocument();
+  });
+
+  it("calls onComplete when complete button is clicked", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<SetupWizard onComplete={onComplete} />);
+    // Navigate to complete step
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("はじめる"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onComplete before reaching complete step", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<SetupWizard onComplete={onComplete} />);
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("does not advance beyond the last step with next", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    // Navigate to complete step
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    // Complete step only has the "はじめる" button, no next
+    expect(screen.getByText("セットアップ完了！")).toBeInTheDocument();
+  });
+
+  it("does not go before step 1 with back", () => {
+    render(<SetupWizard onComplete={vi.fn()} />);
+    // Back button should not be visible on step 1
+    expect(screen.queryByText("戻る")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "リポジトリ選択" })
+    ).toBeInTheDocument();
+  });
+
+  it("skip behaves the same as next (advances one step)", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("スキップ"));
+    expect(screen.getByText("ステップ 2 / 4")).toBeInTheDocument();
+  });
+
+  it("does not render Card on complete step", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizard onComplete={vi.fn()} />);
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    await user.click(screen.getByText("次へ"));
+    // On complete step, description should be shown but no Card with step title inside
+    expect(screen.getByText("セットアップ完了！")).toBeInTheDocument();
+    // The step title appears in the heading, but not in a Card placeholder
+    const headings = screen.getAllByText("セットアップ完了！");
+    expect(headings).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/SetupWizardStep2.test.tsx
+++ b/frontend/src/components/SetupWizardStep2.test.tsx
@@ -1,0 +1,263 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SetupWizardStep2 } from "./SetupWizardStep2";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "onboarding.step2Title": "GitHub認証",
+        "onboarding.step2Description": "GitHubと連携します。",
+        "onboarding.deviceFlowStart": "GitHubでログイン",
+        "onboarding.deviceFlowInstruction":
+          "以下のコードをGitHubで入力してください:",
+        "onboarding.deviceFlowOpenBrowser": "ブラウザで開く",
+        "onboarding.deviceFlowWaiting": "認証を待っています…",
+        "onboarding.deviceFlowSuccess": "GitHub認証が完了しました",
+        "onboarding.deviceFlowExpired":
+          "認証コードの有効期限が切れました。再度お試しください。",
+        "onboarding.manualTokenLabel":
+          "または、Personal Access Tokenを手動入力",
+        "onboarding.manualTokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxx",
+        "onboarding.manualTokenSave": "トークンを保存",
+        "onboarding.manualTokenSaving": "保存中…",
+        "onboarding.manualTokenSuccess": "トークンを保存しました",
+        "onboarding.showToken": "表示",
+        "onboarding.hideToken": "非表示",
+        "onboarding.skip": "スキップ",
+        "onboarding.skipNote":
+          "スキップしても、あとから設定画面でGitHub認証を行えます。",
+        "onboarding.next": "次へ",
+      };
+      if (key === "onboarding.deviceFlowError" && params) {
+        return `認証に失敗しました: ${params.message}`;
+      }
+      if (key === "onboarding.manualTokenError" && params) {
+        return `トークンの保存に失敗しました: ${params.message}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+const mockInvokeFn = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvokeFn(...args),
+}));
+
+describe("SetupWizardStep2", () => {
+  const defaultProps = {
+    onNext: vi.fn(),
+    onSkip: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the title and description", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    expect(screen.getByText("GitHub認証")).toBeInTheDocument();
+    expect(screen.getByText("GitHubと連携します。")).toBeInTheDocument();
+  });
+
+  it("renders device flow start button", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    expect(screen.getByText("GitHubでログイン")).toBeInTheDocument();
+  });
+
+  it("renders manual token input section", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    expect(
+      screen.getByText("または、Personal Access Tokenを手動入力")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx")
+    ).toBeInTheDocument();
+    expect(screen.getByText("トークンを保存")).toBeInTheDocument();
+  });
+
+  it("renders skip button", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    expect(screen.getByText("スキップ")).toBeInTheDocument();
+  });
+
+  it("calls onSkip when skip button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+    render(<SetupWizardStep2 {...defaultProps} onSkip={onSkip} />);
+    await user.click(screen.getByText("スキップ"));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables save button when token is empty", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    const saveButton = screen.getByText("トークンを保存").closest("button")!;
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("enables save button when token is entered", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    const saveButton = screen.getByText("トークンを保存").closest("button")!;
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it("saves token and shows success message", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    await user.click(screen.getByText("トークンを保存"));
+    await waitFor(() => {
+      expect(screen.getByText("トークンを保存しました")).toBeInTheDocument();
+    });
+    expect(mockInvokeFn).toHaveBeenCalledWith("save_github_token", {
+      token: "ghp_test123",
+    });
+  });
+
+  it("shows error message when save fails", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockRejectedValueOnce(new Error("Network error"));
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    await user.click(screen.getByText("トークンを保存"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/トークンの保存に失敗しました:.*Network error/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows next button after successful token save", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    await user.click(screen.getByText("トークンを保存"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onNext when next button is clicked after auth", async () => {
+    const user = userEvent.setup();
+    const onNext = vi.fn();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep2 {...defaultProps} onNext={onNext} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    await user.click(screen.getByText("トークンを保存"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("次へ"));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles token visibility", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizardStep2 {...defaultProps} />);
+    const tokenInput = screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx");
+    expect(tokenInput).toHaveAttribute("type", "password");
+    await user.click(screen.getByText("表示"));
+    expect(tokenInput).toHaveAttribute("type", "text");
+    await user.click(screen.getByText("非表示"));
+    expect(tokenInput).toHaveAttribute("type", "password");
+  });
+
+  it("shows device flow polling state after starting", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockImplementation((command: string) => {
+      if (command === "start_github_device_flow") {
+        return Promise.resolve({
+          device_code: "dc_123",
+          user_code: "ABCD-1234",
+          verification_uri: "https://github.com/login/device",
+          interval: 5,
+          expires_in: 900,
+        });
+      }
+      // poll_github_device_flow - keep pending to stay in polling state
+      return new Promise(() => {});
+    });
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.click(screen.getByText("GitHubでログイン"));
+    await waitFor(() => {
+      expect(screen.getByText("ABCD-1234")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("以下のコードをGitHubで入力してください:")
+    ).toBeInTheDocument();
+    expect(screen.getByText("ブラウザで開く")).toBeInTheDocument();
+    expect(screen.getByText("認証を待っています…")).toBeInTheDocument();
+  });
+
+  it("shows error when device flow start fails", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockRejectedValueOnce(new Error("API unavailable"));
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.click(screen.getByText("GitHubでログイン"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/認証に失敗しました:.*API unavailable/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides manual token section after successful auth", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "ghp_test123"
+    );
+    await user.click(screen.getByText("トークンを保存"));
+    await waitFor(() => {
+      expect(screen.getByText("トークンを保存しました")).toBeInTheDocument();
+    });
+    // Manual token section should be hidden after auth
+    expect(
+      screen.queryByText("または、Personal Access Tokenを手動入力")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows skip note when not authenticated", () => {
+    render(<SetupWizardStep2 {...defaultProps} />);
+    expect(
+      screen.getByText(
+        "スキップしても、あとから設定画面でGitHub認証を行えます。"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does not save when token is whitespace only", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizardStep2 {...defaultProps} />);
+    await user.type(
+      screen.getByPlaceholderText("ghp_xxxxxxxxxxxxxxxxxxxx"),
+      "   "
+    );
+    const saveButton = screen.getByText("トークンを保存").closest("button")!;
+    expect(saveButton).toBeDisabled();
+  });
+});

--- a/frontend/src/components/SetupWizardStep3.test.tsx
+++ b/frontend/src/components/SetupWizardStep3.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SetupWizardStep3 } from "./SetupWizardStep3";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "onboarding.step3Title": "LLM設定",
+        "onboarding.step3Description": "APIキーを設定します。",
+        "onboarding.step3TestSuccess": "接続テストに成功しました",
+        "onboarding.step3SaveSuccess": "LLM設定を保存しました",
+        "onboarding.step3SkipNote":
+          "スキップしても、あとから設定画面でLLM設定を行えます。",
+        "onboarding.skip": "スキップ",
+        "onboarding.next": "次へ",
+        "llmSettings.endpoint": "エンドポイントURL",
+        "llmSettings.model": "モデル名",
+        "llmSettings.apiKey": "APIキー",
+        "llmSettings.apiKeyPlaceholder": "APIキーを入力",
+        "llmSettings.testConnection": "接続テスト",
+        "llmSettings.showApiKey": "表示",
+        "llmSettings.hideApiKey": "非表示",
+      };
+      if (key === "onboarding.step3TestError" && params) {
+        return `接続テストに失敗しました: ${params.message}`;
+      }
+      if (key === "onboarding.step3SaveError" && params) {
+        return `LLM設定の保存に失敗しました: ${params.message}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+const mockInvokeFn = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvokeFn(...args),
+}));
+
+describe("SetupWizardStep3", () => {
+  const defaultProps = {
+    onNext: vi.fn(),
+    onSkip: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the title and description", () => {
+    render(<SetupWizardStep3 {...defaultProps} />);
+    expect(screen.getByText("LLM設定")).toBeInTheDocument();
+    expect(screen.getByText("APIキーを設定します。")).toBeInTheDocument();
+  });
+
+  it("renders input fields with default values", () => {
+    render(<SetupWizardStep3 {...defaultProps} />);
+    const endpointInput = screen.getByDisplayValue("https://api.anthropic.com");
+    expect(endpointInput).toBeInTheDocument();
+    const modelInput = screen.getByDisplayValue("claude-sonnet-4-5-20250929");
+    expect(modelInput).toBeInTheDocument();
+  });
+
+  it("renders API key input and test connection button", () => {
+    render(<SetupWizardStep3 {...defaultProps} />);
+    expect(screen.getByPlaceholderText("APIキーを入力")).toBeInTheDocument();
+    expect(screen.getByText("接続テスト")).toBeInTheDocument();
+  });
+
+  it("renders skip button", () => {
+    render(<SetupWizardStep3 {...defaultProps} />);
+    expect(screen.getByText("スキップ")).toBeInTheDocument();
+  });
+
+  it("calls onSkip when skip button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+    render(<SetupWizardStep3 {...defaultProps} onSkip={onSkip} />);
+    await user.click(screen.getByText("スキップ"));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows skip note when test has not succeeded", () => {
+    render(<SetupWizardStep3 {...defaultProps} />);
+    expect(
+      screen.getByText("スキップしても、あとから設定画面でLLM設定を行えます。")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("次へ")).not.toBeInTheDocument();
+  });
+
+  it("runs test connection and shows success", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep3 {...defaultProps} />);
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText("接続テストに成功しました")).toBeInTheDocument();
+    });
+    expect(mockInvokeFn).toHaveBeenCalledWith("test_llm_connection", {
+      endpoint: "https://api.anthropic.com",
+      model: "claude-sonnet-4-5-20250929",
+      apiKey: undefined,
+    });
+  });
+
+  it("shows next button after successful test", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep3 {...defaultProps} />);
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when test fails", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockRejectedValueOnce(new Error("Invalid API key"));
+    render(<SetupWizardStep3 {...defaultProps} />);
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/接続テストに失敗しました:.*Invalid API key/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show next button after test failure", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockRejectedValueOnce(new Error("fail"));
+    render(<SetupWizardStep3 {...defaultProps} />);
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText(/接続テストに失敗しました/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("次へ")).not.toBeInTheDocument();
+  });
+
+  it("saves config and calls onNext on next button click", async () => {
+    const user = userEvent.setup();
+    const onNext = vi.fn();
+    // First call: test_llm_connection, subsequent: save_llm_config
+    mockInvokeFn.mockResolvedValue(undefined);
+    render(<SetupWizardStep3 {...defaultProps} onNext={onNext} />);
+
+    // First test connection
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+
+    // Click next (which triggers save)
+    await user.click(screen.getByText("次へ"));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    expect(mockInvokeFn).toHaveBeenCalledWith("save_llm_config", {
+      llmConfig: {
+        llm_endpoint: "https://api.anthropic.com",
+        llm_model: "claude-sonnet-4-5-20250929",
+        llm_api_key_stored: false,
+      },
+    });
+  });
+
+  it("saves API key when provided", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValue(undefined);
+    render(<SetupWizardStep3 {...defaultProps} />);
+
+    // Enter API key
+    await user.type(
+      screen.getByPlaceholderText("APIキーを入力"),
+      "sk-test-key"
+    );
+
+    // Test connection
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+
+    // Save
+    await user.click(screen.getByText("次へ"));
+    await waitFor(() => {
+      expect(mockInvokeFn).toHaveBeenCalledWith("save_llm_api_key", {
+        apiKey: "sk-test-key",
+      });
+    });
+  });
+
+  it("shows save error when save fails", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn
+      .mockResolvedValueOnce(undefined) // test_llm_connection succeeds
+      .mockRejectedValueOnce(new Error("Save failed")); // save_llm_config fails
+    render(<SetupWizardStep3 {...defaultProps} />);
+
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(screen.getByText("次へ")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("次へ"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/LLM設定の保存に失敗しました:.*Save failed/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("toggles API key visibility", async () => {
+    const user = userEvent.setup();
+    render(<SetupWizardStep3 {...defaultProps} />);
+    const apiKeyInput = screen.getByPlaceholderText("APIキーを入力");
+    expect(apiKeyInput).toHaveAttribute("type", "password");
+    await user.click(screen.getByText("表示"));
+    expect(apiKeyInput).toHaveAttribute("type", "text");
+    await user.click(screen.getByText("非表示"));
+    expect(apiKeyInput).toHaveAttribute("type", "password");
+  });
+
+  it("sends custom endpoint and model in test connection", async () => {
+    const user = userEvent.setup();
+    mockInvokeFn.mockResolvedValueOnce(undefined);
+    render(<SetupWizardStep3 {...defaultProps} />);
+
+    const endpointInput = screen.getByDisplayValue("https://api.anthropic.com");
+    const modelInput = screen.getByDisplayValue("claude-sonnet-4-5-20250929");
+
+    await user.clear(endpointInput);
+    await user.type(endpointInput, "https://custom.api.com");
+    await user.clear(modelInput);
+    await user.type(modelInput, "custom-model");
+
+    await user.click(screen.getByText("接続テスト"));
+    await waitFor(() => {
+      expect(mockInvokeFn).toHaveBeenCalledWith("test_llm_connection", {
+        endpoint: "https://custom.api.com",
+        model: "custom-model",
+        apiKey: undefined,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #601: test: SetupWizard のユニットテストを追加する

ステップ遷移ロジック（next/back/skip）やonCompleteコールバックの呼び出しを検証するユニットテストがない。VRTはあるがインタラクションの検証が不足している

---
_レビューエージェントが #502 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #601

---
Generated by agent/loop.sh