### PR TITLE
refactor: refactor: `git_add_safe` の while ループをサブシェル問題に対応

### DIFF
--- a/agent/lib/30_git.sh
+++ b/agent/lib/30_git.sh
@@ -107,9 +107,16 @@ git_add_safe() {
   local untracked
   untracked=$(git ls-files --others --exclude-standard)
   if [[ -n "$untracked" ]]; then
-    echo "$untracked" | grep -E '\.(rs|toml|lock|ts|tsx|js|jsx|json|css|html|md|sh|yaml|yml|svg|png)$' | while IFS= read -r f; do
-      git add -- "$f"
-    done
+    local add_failed=0
+    while IFS= read -r f; do
+      if ! git add -- "$f"; then
+        log "WARN: git add failed for: $f"
+        add_failed=1
+      fi
+    done < <(echo "$untracked" | grep -E '\.(rs|toml|lock|ts|tsx|js|jsx|json|css|html|md|sh|yaml|yml|svg|png)$')
+    if [[ "$add_failed" -ne 0 ]]; then
+      log "WARN: Some files failed to stage"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Implements issue #612: refactor: `git_add_safe` の while ループをサブシェル問題に対応

agent/lib/30_git.sh:110 — `echo | grep | while` のパイプラインにより `while` ループがサブシェルで実行される。現状は `git add` の失敗が無視される。`xargs` や process substitution (`while read ... < <(grep ...)`) に置換すると堅牢になる。

---
_レビューエージェントが #554 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #612

---
Generated by agent/loop.sh