### PR TITLE
refactor: refactor: `05_verify.sh` と `05b_review.sh` の `git add -A` も `git_add_safe` に置換

### DIFF
--- a/agent/steps/05_verify.sh
+++ b/agent/steps/05_verify.sh
@@ -27,11 +27,11 @@ step_verify() {
       (cd "$REPO_ROOT/frontend" && npx playwright test --update-snapshots 2>/dev/null) || true
     fi
 
-    git add -A
+    git_add_safe
     if ! git commit -m "fix: apply formatting for #$TASK_ISSUE" 2>/dev/null; then
       # Hook failed after formatting — bypass to avoid blocking
       log "WARN: Formatter commit failed (pre-commit hook). Bypassing hook."
-      git add -A
+      git_add_safe
       git commit --no-verify -m "fix: apply formatting for #$TASK_ISSUE" 2>/dev/null || true
     fi
   fi
@@ -98,7 +98,7 @@ step_verify() {
   cd "$REPO_ROOT"
   if ! git diff --quiet || ! git diff --cached --quiet || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
     log "WARN: Working tree not clean after checks. Committing remaining changes..."
-    git add -A
+    git_add_safe
     if ! git commit -m "fix: commit remaining changes for #$TASK_ISSUE" 2>/dev/null; then
       # Pre-commit hook failed — run formatters and retry
       log "WARN: Commit failed (pre-commit hook). Re-running formatters..."
@@ -107,7 +107,7 @@ step_verify() {
         (cd "$REPO_ROOT/frontend" && npx prettier --write src/ 2>/dev/null) || true
         (cd "$REPO_ROOT/frontend" && npx eslint --fix src/ 2>/dev/null) || true
       fi
-      git add -A
+      git_add_safe
       if ! git commit -m "fix: commit remaining changes for #$TASK_ISSUE" 2>/dev/null; then
         # Hook still fails — bypass hook to avoid blocking pipeline
         log "WARN: Commit still failing. Bypassing pre-commit hook."

--- a/agent/steps/05b_review.sh
+++ b/agent/steps/05b_review.sh
@@ -91,7 +91,7 @@ $BLOCKING_DESC
 
     if ! git diff --quiet || ! git diff --cached --quiet || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
       log "WARN: Fix agent left uncommitted changes. Committing..."
-      git add -A
+      git_add_safe
       git commit -m "fix: address review blocking issues for #$TASK_ISSUE" 2>/dev/null || fix_success=false
     fi
 


### PR DESCRIPTION
## Summary

Implements issue #613: refactor: `05_verify.sh` と `05b_review.sh` の `git add -A` も `git_add_safe` に置換

agent/steps/05_verify.sh:30,34,101,110 と agent/steps/05b_review.sh:94 でまだ `git add -A` が使用されている。同じリスクがあるため、`git_add_safe` に統一すべき。

---
_レビューエージェントが #554 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #613

---
Generated by agent/loop.sh