### PR TITLE
fix: fix: 同じブランチを連続クリックした際に navigateToBranch が再発火しない

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,6 +143,10 @@ export function App() {
     setSettingsOpen(false);
   }, []);
 
+  const handleNavigateConsumed = useCallback(() => {
+    setNavigateToBranch(null);
+  }, []);
+
   const dismissAddRepoError = useCallback(() => {
     setAddRepoError(null);
     clearTimeout(addErrorTimerRef.current);
@@ -271,6 +275,7 @@ export function App() {
               prs={prs}
               loadingPrs={loadingPrs}
               navigateToBranch={navigateToBranch}
+              onNavigateConsumed={handleNavigateConsumed}
             />
           )}
           {activeTab === "next-action" && (

--- a/frontend/src/components/ReviewTab.tsx
+++ b/frontend/src/components/ReviewTab.tsx
@@ -145,12 +145,14 @@ interface ReviewTabProps {
   prs?: PrInfo[];
   loadingPrs?: boolean;
   navigateToBranch?: string | null;
+  onNavigateConsumed?: () => void;
 }
 
 export function ReviewTab({
   prs = [],
   loadingPrs = false,
   navigateToBranch,
+  onNavigateConsumed,
 }: ReviewTabProps) {
   const { t } = useTranslation();
   const { repoPath, repoInfo } = useRepository();
@@ -167,8 +169,9 @@ export function ReviewTab({
   useEffect(() => {
     if (navigateToBranch) {
       setSelectedBranch(navigateToBranch);
+      onNavigateConsumed?.();
     }
-  }, [navigateToBranch]);
+  }, [navigateToBranch, onNavigateConsumed]);
 
   const [diffs, setDiffs] = useState<FileDiff[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);


### PR DESCRIPTION
## Summary

Implements issue #615: fix: 同じブランチを連続クリックした際に navigateToBranch が再発火しない

frontend/src/components/ReviewTab.tsx:259 — useEffect は navigateToBranch の値が変化した時のみ発火するため、同じブランチを2回続けてクリックしても再ナビゲーションされない。App 側で setNavigateToBranch(null) をしてから再セットする等の対応が必要。現状は致命的ではないが、UX改善として検討すべき。

---
_レビューエージェントが #558 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #615

---
Generated by agent/loop.sh