### PR TITLE
chore: chore: フロントエンド invoke.ts に run_auto_approve の型定義を追加する

### DIFF
--- a/frontend/src/invoke.ts
+++ b/frontend/src/invoke.ts
@@ -22,6 +22,7 @@ import type {
   TodoItem,
   ReviewSuggestion,
   AutoApproveCandidate,
+  AutoApproveResult,
   AutoApproveWithMergeResult,
   DeviceFlowResponse,
 } from "./types";
@@ -147,6 +148,10 @@ export type Commands = {
   evaluate_auto_approve_candidates: {
     args: { owner: string; repo: string };
     ret: AutoApproveCandidate[];
+  };
+  run_auto_approve: {
+    args: { owner: string; repo: string };
+    ret: AutoApproveResult;
   };
   run_auto_approve_with_merge: {
     args: {

--- a/frontend/src/storybook/tauri-invoke-mock.ts
+++ b/frontend/src/storybook/tauri-invoke-mock.ts
@@ -49,6 +49,7 @@ const defaultHandlers: CommandHandlers = {
   create_worktree_for_todo: () => fixtures.worktrees[1],
   suggest_review_comments: () => fixtures.reviewSuggestions,
   evaluate_auto_approve_candidates: () => [],
+  run_auto_approve: () => ({ outcomes: [] }),
   run_auto_approve_with_merge: () => fixtures.autoApproveWithMergeResult,
   load_risk_config: () => fixtures.automationConfig.risk_config,
   save_risk_config: () => undefined as never,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,6 +259,16 @@ export interface AutoApproveCandidate {
   reason: string;
 }
 
+export interface ApproveOutcome {
+  pr_number: number;
+  success: boolean;
+  error: string | null;
+}
+
+export interface AutoApproveResult {
+  outcomes: ApproveOutcome[];
+}
+
 export type AutoMergeStatus =
   | "Enabled"
   | "Skipped"


### PR DESCRIPTION
## Summary

Implements issue #531: chore: フロントエンド invoke.ts に run_auto_approve の型定義を追加する

frontend/src/invoke.ts — run_auto_approve コマンドは backend に登録されているが、フロントエンドの Commands 型定義に含まれていない。ただしこれは今回の変更以前から存在する問題で、本 PR のスコープ外。

---
_レビューエージェントが #509 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #531

---
Generated by agent/loop.sh