### PR TITLE
fix: ボタンスタイルの一貫性を改善する

### DIFF
--- a/frontend/e2e/vrt/button.spec.ts
+++ b/frontend/e2e/vrt/button.spec.ts
@@ -55,4 +55,22 @@ test.describe("Button", () => {
       { maxDiffPixelRatio: 0.08 }
     );
   });
+
+  test("filter variant", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-button--filter&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "filter.png"
+    );
+  });
+
+  test("filter active variant", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-button--filter-active&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "filter-active.png"
+    );
+  });
 });

--- a/frontend/src/components/Button.stories.tsx
+++ b/frontend/src/components/Button.stories.tsx
@@ -64,3 +64,20 @@ export const Loading: Story = {
     children: "読み込み中",
   },
 };
+
+export const Filter: Story = {
+  args: {
+    variant: "filter",
+    size: "sm",
+    children: "フィルター",
+  },
+};
+
+export const FilterActive: Story = {
+  args: {
+    variant: "filter",
+    size: "sm",
+    active: true,
+    children: "フィルター（選択中）",
+  },
+};

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,12 +1,13 @@
 import { ButtonHTMLAttributes, forwardRef } from "react";
 
-type Variant = "primary" | "secondary" | "destructive" | "ghost";
+type Variant = "primary" | "secondary" | "destructive" | "ghost" | "filter";
 type Size = "sm" | "md" | "lg";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
   size?: Size;
   loading?: boolean;
+  active?: boolean;
 }
 
 const variantClasses: Record<Variant, string> = {
@@ -18,7 +19,12 @@ const variantClasses: Record<Variant, string> = {
     "bg-transparent text-danger border border-danger font-semibold hover:bg-danger hover:text-white",
   ghost:
     "bg-transparent text-text-primary border border-transparent hover:bg-bg-hover hover:border-border-hover",
+  filter:
+    "bg-bg-hover text-text-secondary font-medium border-none hover:text-text-primary",
 };
+
+const filterActiveClasses =
+  "bg-accent text-white font-bold shadow-sm ring-1 ring-accent";
 
 const sizeClasses: Record<Size, string> = {
   sm: "px-2 py-1 text-sm",
@@ -32,6 +38,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = "primary",
       size = "md",
       loading = false,
+      active = false,
       disabled,
       className = "",
       children,
@@ -39,11 +46,16 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
+    const variantClass =
+      variant === "filter" && active
+        ? filterActiveClasses
+        : variantClasses[variant];
+
     return (
       <button
         ref={ref}
         disabled={disabled || loading}
-        className={`cursor-pointer rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+        className={`cursor-pointer rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${variantClass} ${sizeClasses[size]} ${className}`}
         {...props}
       >
         {loading ? (

--- a/frontend/src/components/ChangeSummaryList.tsx
+++ b/frontend/src/components/ChangeSummaryList.tsx
@@ -74,30 +74,26 @@ function CategoryFilter({
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap gap-2">
-        <button
-          className={`rounded px-3 py-1 text-xs transition-colors ${
-            isAllActive
-              ? "bg-accent text-bg-primary font-bold shadow-sm ring-1 ring-accent"
-              : "bg-bg-hover text-text-secondary font-medium hover:text-text-primary"
-          }`}
+        <Button
+          variant="filter"
+          size="sm"
+          active={isAllActive}
           onClick={onShowAll}
         >
           {t("pr.categoryFilterAll")}
-        </button>
+        </Button>
         {presentCategories.map((category) => {
           const isActive = activeCategories.has(category);
           return (
-            <button
+            <Button
               key={category}
-              className={`rounded px-3 py-1 text-xs transition-colors ${
-                isActive
-                  ? "bg-accent text-bg-primary font-bold shadow-sm ring-1 ring-accent"
-                  : "bg-bg-hover text-text-secondary font-medium hover:text-text-primary"
-              }`}
+              variant="filter"
+              size="sm"
+              active={isActive}
               onClick={() => onToggle(category)}
             >
               {categoryIcons[category]} {t(categoryLabelKeys[category])}
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/frontend/src/components/PrListView.tsx
+++ b/frontend/src/components/PrListView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { PrInfo, CommitInfo, RiskLevel } from "../types";
 import { invoke } from "../invoke";
 import { Badge } from "./Badge";
+import { Button } from "./Button";
 import { Card } from "./Card";
 import { CommitListPanel } from "./CommitListPanel";
 import { EmptyState } from "./EmptyState";
@@ -147,17 +148,15 @@ export function PrListView({
 
       <div className="mb-4 flex gap-1">
         {filters.map((f) => (
-          <button
+          <Button
             key={f.key}
-            className={`rounded-t px-3 py-1.5 text-sm transition-colors ${
-              filter === f.key
-                ? "border-b-2 border-b-accent bg-accent/10 font-bold text-accent"
-                : "border-b-2 border-b-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary"
-            }`}
+            variant="filter"
+            size="sm"
+            active={filter === f.key}
             onClick={() => setFilter(f.key)}
           >
             {f.label}
-          </button>
+          </Button>
         ))}
       </div>
 

--- a/frontend/src/components/TodoTab.tsx
+++ b/frontend/src/components/TodoTab.tsx
@@ -196,13 +196,11 @@ export function TodoTab({ onNavigateToBranch }: TodoTabProps) {
         {todos.length > 0 && (
           <div className="mb-3 flex items-center gap-2">
             {(["all", "Todo", "Fixme"] as const).map((f) => (
-              <button
+              <Button
                 key={f}
-                className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
-                  filter === f
-                    ? "bg-accent text-bg-primary"
-                    : "bg-bg-hover text-text-secondary hover:text-text-primary"
-                }`}
+                variant="filter"
+                size="sm"
+                active={filter === f}
                 onClick={() => setFilter(f)}
               >
                 {f === "all"
@@ -210,7 +208,7 @@ export function TodoTab({ onNavigateToBranch }: TodoTabProps) {
                   : f === "Todo"
                     ? t("todo.filterTodo")
                     : t("todo.filterFixme")}
-              </button>
+              </Button>
             ))}
             <div className="ml-auto">
               <button


### PR DESCRIPTION
## Summary

Implements issue #465: ボタンスタイルの一貫性を改善する

## 概要

複数のコンポーネントで `Button` コンポーネントを使わずに独自スタイルの `<button>` 要素が使われており、スタイルの一貫性が崩れている。これを統一する。

## 現状の問題

以下のコンポーネントで `Button` コンポーネントではなくカスタムスタイルの `<button>` が使われている：
- **CategoryFilter ボタン** (`ChangeSummaryList.tsx`): `bg-accent text-bg-primary` / `bg-bg-hover text-text-secondary`
- **PrListView フィルタボタン** (`PrListView.tsx`): `bg-accent text-white` / `bg-btn-secondary text-text-secondary`
- **TodoTab フィルタボタン** (`TodoTab.tsx`): `bg-accent text-bg-primary` / `bg-bg-hover text-text-secondary`
- active 状態の色が `text-bg-primary` と `text-white` で不統一

## Acceptance Criteria

- [ ] フィルタ/トグル系ボタンのスタイルを統一する（必要に応じて `Button` に `filter` variant を追加、または共通クラスを定義）
- [ ] active 状態のテキスト色を統一する（`text-bg-primary` or `text-white` のどちらかに揃える）
- [ ] 該当する Storybook stories を更新する
- [ ] VRT スペックを更新する
- [ ] `npm run build` が通る

## 対象ファイル

- `frontend/src/components/Button.tsx`
- `frontend/src/components/ChangeSummaryList.tsx`
- `frontend/src/components/PrListView.tsx`
- `frontend/src/components/TodoTab.tsx`
- 関連する `*.stories.tsx` / `e2e/vrt/*.spec.ts`

Parent: #463

Closes #465

---
Generated by agent/loop.sh