### PR TITLE
style: style: focus-visible ring-offset の背景色を明示的に指定

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -69,7 +69,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={disabled || loading}
-        className={`cursor-pointer ${roundedClass} transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${variantClass} ${sizeClasses[size]} ${className}`}
+        className={`cursor-pointer ${roundedClass} transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bg-primary disabled:cursor-not-allowed disabled:opacity-50 ${variantClass} ${sizeClasses[size]} ${className}`}
         {...props}
       >
         {loading ? (


### PR DESCRIPTION
## Summary

Implements issue #560: style: focus-visible ring-offset の背景色を明示的に指定

frontend/src/components/Button.tsx:46 — `ring-offset-1` は `ring-offset-color` のデフォルト（白）を使用する。ダークモードでは offset 部分が白く見える可能性がある。`focus-visible:ring-offset-bg-primary` 等で背景色を明示指定すると良い

---
_レビューエージェントが #446 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #560

---
Generated by agent/loop.sh