### PR TITLE
style: refactor: accent-hover の方向を明示的にコメントで説明する

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -10,6 +10,7 @@
   --color-text-secondary: #4b5563;
   --color-text-muted: #6b7280;
   --color-text-heading: #111827;
+  /* accent は暗め、accent-hover は明るめ — コントラスト改善のため意図的に通常と逆方向 */
   --color-accent: #0f766e;
   --color-accent-hover: #0d9488;
   --color-danger: #dc2626;
@@ -51,6 +52,7 @@ html.dark {
   --color-text-secondary: #d1d5db;
   --color-text-muted: #9ca3af;
   --color-text-heading: #f9fafb;
+  /* accent は暗め、accent-hover は明るめ — コントラスト改善のため意図的に通常と逆方向 */
   --color-accent: #14b8a6;
   --color-accent-hover: #2dd4bf;
   --color-danger: #f87171;


### PR DESCRIPTION
## Summary

Implements issue #568: refactor: accent-hover の方向を明示的にコメントで説明する

frontend/src/style.css:13-14, 52-53 — accent と accent-hover の値が従来と逆転されている（暗い色がデフォルト、明るい色がホバー）。コントラスト改善のための意図的な変更だが、将来の混乱を避けるためコメントがあると良い。

---
_レビューエージェントが #466 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #568

---
Generated by agent/loop.sh