### PR TITLE
refactor: refactor: LLM risk_warnings のスタイルを ImpactWarnings コンポーネントに統合する

### DIFF
--- a/frontend/src/components/AnalysisDetailPanel.tsx
+++ b/frontend/src/components/AnalysisDetailPanel.tsx
@@ -38,6 +38,15 @@ const categoryLabelKeys: Record<ChangeCategory, string> = {
   Other: "pr.categoryOther",
 };
 
+function WarningBanner({ message }: { message: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded border border-warning/30 bg-warning/10 px-3 py-1.5 text-[0.8rem] text-warning">
+      <span>&#x26A0;&#xFE0F;</span>
+      <span>{message}</span>
+    </div>
+  );
+}
+
 function ImpactWarnings({ factors }: { factors: RiskFactor[] }) {
   const { t } = useTranslation();
 
@@ -85,13 +94,7 @@ function ImpactWarnings({ factors }: { factors: RiskFactor[] }) {
   return (
     <div className="space-y-1">
       {warnings.map((warning, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-2 rounded border border-warning/30 bg-warning/10 px-3 py-1.5 text-[0.8rem] text-warning"
-        >
-          <span>&#x26A0;&#xFE0F;</span>
-          <span>{warning}</span>
-        </div>
+        <WarningBanner key={i} message={warning} />
       ))}
     </div>
   );
@@ -248,13 +251,7 @@ export function AnalysisDetailPanel({
           </h3>
           <div className="space-y-1">
             {hybridResult.llm_analysis.risk_warnings.map((warning, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-2 rounded border border-warning/30 bg-warning/10 px-3 py-1.5 text-[0.8rem] text-warning"
-              >
-                <span>&#x26A0;&#xFE0F;</span>
-                <span>{warning}</span>
-              </div>
+              <WarningBanner key={i} message={warning} />
             ))}
           </div>
         </Panel>


### PR DESCRIPTION
## Summary

Implements issue #573: refactor: LLM risk_warnings のスタイルを ImpactWarnings コンポーネントに統合する

frontend/src/components/AnalysisDetailPanel.tsx:90,253 — ImpactWarnings（L90）と LLM Warnings（L253）のクラス名が完全に同一（`flex items-center gap-2 rounded border border-warning/30 bg-warning/10 px-3 py-1.5 text-[0.8rem] text-warning`）。重複を避けるため、共通の WarningBanner コンポーネントへの抽出を検討すべき

---
_レビューエージェントが #470 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #573

---
Generated by agent/loop.sh