### PR TITLE
refactor: refactor: ラベル付与失敗のログをeprintlnからtracing等の構造化ログに変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4298,7 +4299,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 keyring = { version = "3", features = ["apple-native"] }
 futures = "0.3"
 tokio = { version = "1", features = ["sync", "time"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/lib/automation/auto_approve.rs
+++ b/lib/automation/auto_approve.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use tracing::warn;
+
 use crate::analysis::{AnalysisResult, ChangeCategory, RiskFactor, RiskLevel};
 use crate::config::{AutoApproveMaxRisk, AutomationConfig};
 use crate::github::pull_request::{add_labels, submit_review, ReviewEvent};
@@ -153,9 +155,10 @@ pub async fn execute_auto_approve(
                 )
                 .await
                 {
-                    eprintln!(
-                        "Warning: ラベル付与に失敗 (PR #{}): {}",
-                        candidate.pr_number, e
+                    warn!(
+                        pr_number = candidate.pr_number,
+                        error = %e,
+                        "ラベル付与に失敗"
                     );
                 }
 


### PR DESCRIPTION
## Summary

Implements issue #580: refactor: ラベル付与失敗のログをeprintlnからtracing等の構造化ログに変更

lib/automation/auto_approve.rs:139 — ラベル付与失敗時に `eprintln!` を使っているが、構造化ログライブラリの導入を検討すべき

---
_レビューエージェントが #479 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #580

---
Generated by agent/loop.sh