### PR TITLE
refactor: refactor: lib/automation, lib/llm の free function 呼び出しを GitHubClient 直接利用に移行

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -294,7 +294,8 @@ async fn summarize_pull_request(
 ) -> Result<reown::llm::summary::PrSummary, AppError> {
     let token = load_github_token()?;
     let llm_client = build_llm_client(&app_handle)?;
-    reown::llm::summary::summarize_pr(&owner, &repo, pr_number, &token, &llm_client)
+    let client = reown::github::GitHubClient::new();
+    reown::llm::summary::summarize_pr(&owner, &repo, pr_number, &token, &llm_client, &client)
         .await
         .map_err(AppError::llm)
 }
@@ -308,9 +309,17 @@ async fn check_pr_consistency(
 ) -> Result<reown::llm::summary::ConsistencyResult, AppError> {
     let token = load_github_token()?;
     let llm_client = build_llm_client(&app_handle)?;
-    reown::llm::summary::check_pr_consistency(&owner, &repo, pr_number, &token, &llm_client)
-        .await
-        .map_err(AppError::llm)
+    let client = reown::github::GitHubClient::new();
+    reown::llm::summary::check_pr_consistency(
+        &owner,
+        &repo,
+        pr_number,
+        &token,
+        &llm_client,
+        &client,
+    )
+    .await
+    .map_err(AppError::llm)
 }
 
 // ── LLM connection test ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements issue #689: refactor: lib/automation, lib/llm の free function 呼び出しを GitHubClient 直接利用に移行

## 概要

`lib/automation/` と `lib/llm/` モジュール内の free function 呼び出しを `GitHubClient` 直接利用に移行する。

## 対象箇所

### lib/automation/auto_approve.rs
- `submit_review()` の呼び出し (L137-144)
- `add_labels()` の呼び出し (L149-155)

### lib/automation/orchestration.rs
- `enable_auto_merge()` の呼び出し (L99)

### lib/llm/summary.rs
- `list_pull_requests()` の呼び出し (L147-148)
- `get_pull_request_files()` の呼び出し (L156-158)

## 方針

- 各関数のシグネチャに `&GitHubClient` を引数として追加するか、関数内で `GitHubClient::new()` を呼ぶかを検討する
- 推奨: 呼び出し元から `&GitHubClient` を受け取る形にして、接続プールの共有を最大化する
- import 文を更新する

## 受け入れ基準

- [ ] `lib/automation/auto_approve.rs` から free function の import がなくなっている
- [ ] `lib/automation/orchestration.rs` から free function の import がなくなっている
- [ ] `lib/llm/summary.rs` から free function の import がなくなっている
- [ ] 代わりに `GitHubClient` を直接利用している
- [ ] `cargo build` が通る
- [ ] `cargo test` が通る
- [ ] `cargo clippy --all-targets -- -D warnings` が通る

Parent: #682

Closes #689

---
Generated by agent/loop.sh