### PR TITLE
fix: test: save_github_token テストの並行実行時の競合リスク

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tracing",
@@ -2938,6 +2939,7 @@ dependencies = [
  "reown",
  "serde",
  "serde_json",
+ "serial_test",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3142,6 +3144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3208,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -3395,6 +3412,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ tempfile = "3.25.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 http = "1"
 mockito = "1"
+serial_test = "3"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,3 +18,4 @@ reown = { path = ".." }
 [dev-dependencies]
 tempfile = "3"
 git2 = "0.20"
+serial_test = "3"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -858,6 +858,7 @@ mod tests {
     use reown::git::diff::{DiffChunk, DiffLineInfo, FileDiff, FileStatus, LineOrigin};
     use reown::git::worktree::WorktreeInfo;
     use reown::github::PrInfo;
+    use serial_test::serial;
     use std::path::PathBuf;
 
     #[test]
@@ -1895,6 +1896,7 @@ mod tests {
     // ── save_github_token コマンドテスト ─────────────────────────────────
 
     #[test]
+    #[serial]
     fn test_cmd_save_github_token_ok() {
         let save_result = super::save_github_token("gho_test-save-cmd-token".to_string());
         if save_result.is_err() {
@@ -1927,6 +1929,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cmd_save_github_token_roundtrip_with_logout() {
         let save_result = super::save_github_token("gho_test-roundtrip-token".to_string());
         if save_result.is_err() {

--- a/lib/config.rs
+++ b/lib/config.rs
@@ -460,6 +460,7 @@ pub fn delete_github_token() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
@@ -1142,6 +1143,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_migrate_github_token_to_keychain_success() {
         // keychainが利用可能かチェック
         let test_result = save_github_token("gho_migration-test-probe");
@@ -1199,6 +1201,7 @@ mod tests {
     // ── GitHub Token Keychain テスト ────────────────────────────────────
 
     #[test]
+    #[serial]
     fn test_save_and_delete_github_token() {
         let save_result = save_github_token("gho_test-github-token-for-reown-test");
         if save_result.is_err() {


### PR DESCRIPTION
## Summary

Implements issue #692: test: save_github_token テストの並行実行時の競合リスク

app/src/main.rs:1870,1893 — test_cmd_save_github_token_ok と test_cmd_save_github_token_roundtrip_with_logout は実際のOS keychainに対して同時に読み書きする可能性がある。#[serial] アトリビュート（serial_test クレート）の導入を検討すべき

---
_レビューエージェントが #582 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #692

---
Generated by agent/loop.sh