### PR TITLE
refactor: refactor: ALL_CATEGORIES の順序を ChangeCategory 型定義と一致させる

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -15,12 +15,12 @@ import type {
 
 const ALL_CATEGORIES: ChangeCategory[] = [
   "Logic",
+  "Refactor",
   "Test",
   "Config",
-  "CI",
   "Documentation",
+  "CI",
   "Dependency",
-  "Refactor",
   "Other",
 ];
 


### PR DESCRIPTION
## Summary

Implements issue #588: refactor: ALL_CATEGORIES の順序を ChangeCategory 型定義と一致させる

frontend/src/components/AutomationSettingsTab.tsx:10-19 — `ALL_CATEGORIES` の順序が `ChangeCategory` 型定義（Logic, Refactor, Test, Config, Documentation, CI, Dependency, Other）と異なっている。Refactor が最後の方に配置されているが、型定義では Logic の直後にある。動作に影響はないが、一貫性のために統一を検討。

---
_レビューエージェントが #499 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #588

---
Generated by agent/loop.sh