### PR TITLE
refactor: refactor: リスト項目の key に index ではなくパターン文字列を使う

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -521,7 +521,7 @@ export function AutomationSettingsTab() {
                 <div className="space-y-1">
                   {riskConfig.sensitive_patterns.map((sp, index) => (
                     <div
-                      key={index}
+                      key={sp.pattern}
                       className="flex items-center gap-2 rounded border border-border bg-bg-primary px-3 py-1.5"
                     >
                       <span className="flex-1 text-[0.8rem] text-text-primary">


### PR DESCRIPTION
## Summary

Implements issue #595: refactor: リスト項目の key に index ではなくパターン文字列を使う

frontend/src/components/AutomationSettingsTab.tsx:460 — `key={index}` を使っているが、削除操作でリストが変更されるため React の再レンダリング効率が悪い。パターン文字列が一意であることを前提にできるなら `key={sp.pattern}` を使うのが望ましい。

---
_レビューエージェントが #500 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #595

---
Generated by agent/loop.sh