### PR TITLE
refactor: refactor: handleSkip と handleNext の重複ロジックを統合する

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -29,12 +29,6 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     }
   }, [currentIndex]);
 
-  const handleSkip = useCallback(() => {
-    if (currentIndex < STEPS.length - 1) {
-      setCurrentIndex((i) => i + 1);
-    }
-  }, [currentIndex]);
-
   const stepTitle = (step: Step): string => {
     switch (step) {
       case "repository":
@@ -111,7 +105,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
             </div>
             <div className="flex items-center gap-2">
               <button
-                onClick={handleSkip}
+                onClick={handleNext}
                 className="cursor-pointer border-none bg-transparent text-sm text-text-muted hover:text-text-secondary hover:underline"
               >
                 {t("onboarding.skip")}


### PR DESCRIPTION
## Summary

Implements issue #599: refactor: handleSkip と handleNext の重複ロジックを統合する

frontend/src/components/SetupWizard.tsx:32-36 — handleSkip は handleNext と完全に同じロジック。将来的にスキップ時の追跡などが異なる可能性はあるが、現時点では統合するか handleNext を直接使用するのがシンプル

---
_レビューエージェントが #502 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #599

---
Generated by agent/loop.sh