### PR TITLE
docs: docs: AppConfig の doc comment を更新する

### DIFF
--- a/lib/config.rs
+++ b/lib/config.rs
@@ -278,7 +278,7 @@ impl Default for LlmConfig {
     }
 }
 
-/// アプリ設定（GitHub トークン等を永続化する）
+/// アプリ設定（リポジトリ既定値・LLM・オートメーション等を永続化する）
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct AppConfig {
     /// デフォルトの GitHub owner


### PR DESCRIPTION
## Summary

Implements issue #606: docs: AppConfig の doc comment を更新する

lib/config.rs:281 — doc comment が「GitHub トークン等を永続化する」のままだが、github_token フィールドは削除済み。実態に合わせて更新すべき

---
_レビューエージェントが #530 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #606

---
Generated by agent/loop.sh