### PR TITLE
refactor: refactor: useFileListPanel フックを FileListPanel と同じファイルに移動する

### DIFF
--- a/frontend/src/components/ReviewTab.tsx
+++ b/frontend/src/components/ReviewTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "../invoke";
 import { useRepository } from "../RepositoryContext";
@@ -18,6 +18,7 @@ import { EmptyState } from "./EmptyState";
 import { Loading } from "./Loading";
 import { DiffViewer } from "./DiffViewer";
 import { FileListPanel } from "./FileListPanel";
+import { useFileListPanel } from "./useFileListPanel";
 import { AnalysisDetailPanel } from "./AnalysisDetailPanel";
 import { ChangeSummaryList } from "./ChangeSummaryList";
 import { CommitListPanel } from "./CommitListPanel";
@@ -27,106 +28,6 @@ import { ReviewSubmit } from "./ReviewSubmit";
 import { AutomationPanel } from "./AutomationPanel";
 import { PrSummaryPanel } from "./PrSummaryPanel";
 import { ReviewHistoryPanel } from "./ReviewHistoryPanel";
-
-const FILE_LIST_WIDTH_KEY = "reown-filelist-width";
-const FILE_LIST_COLLAPSED_KEY = "reown-filelist-collapsed";
-const DEFAULT_FILE_LIST_WIDTH = 280;
-const MIN_FILE_LIST_WIDTH = 180;
-const MAX_FILE_LIST_WIDTH = 480;
-
-function useFileListPanel() {
-  const [fileListWidth, setFileListWidth] = useState(() => {
-    try {
-      const stored = localStorage.getItem(FILE_LIST_WIDTH_KEY);
-      if (stored) {
-        const parsed = Number(stored);
-        if (parsed >= MIN_FILE_LIST_WIDTH && parsed <= MAX_FILE_LIST_WIDTH) {
-          return parsed;
-        }
-      }
-    } catch {
-      // ignore
-    }
-    return DEFAULT_FILE_LIST_WIDTH;
-  });
-  const [collapsed, setCollapsed] = useState(() => {
-    try {
-      return localStorage.getItem(FILE_LIST_COLLAPSED_KEY) === "true";
-    } catch {
-      return false;
-    }
-  });
-  const [resizing, setResizing] = useState(false);
-  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
-
-  const toggleCollapse = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(FILE_LIST_COLLAPSED_KEY, String(next));
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  }, []);
-
-  const handleResizeStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      resizeRef.current = { startX: e.clientX, startWidth: fileListWidth };
-      setResizing(true);
-    },
-    [fileListWidth]
-  );
-
-  useEffect(() => {
-    if (!resizing) return;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!resizeRef.current) return;
-      const delta = e.clientX - resizeRef.current.startX;
-      const newWidth = Math.min(
-        MAX_FILE_LIST_WIDTH,
-        Math.max(MIN_FILE_LIST_WIDTH, resizeRef.current.startWidth + delta)
-      );
-      setFileListWidth(newWidth);
-    };
-
-    const handleMouseUp = () => {
-      setResizing(false);
-      resizeRef.current = null;
-    };
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-    };
-  }, [resizing]);
-
-  // Persist width when resizing ends
-  const prevResizingRef = useRef(false);
-  useEffect(() => {
-    if (prevResizingRef.current && !resizing) {
-      try {
-        localStorage.setItem(FILE_LIST_WIDTH_KEY, String(fileListWidth));
-      } catch {
-        // ignore
-      }
-    }
-    prevResizingRef.current = resizing;
-  }, [resizing, fileListWidth]);
-
-  return {
-    fileListWidth,
-    collapsed,
-    resizing,
-    toggleCollapse,
-    handleResizeStart,
-  };
-}
 
 const categoryBadgeVariant: Record<
   string,

--- a/frontend/src/components/useFileListPanel.ts
+++ b/frontend/src/components/useFileListPanel.ts
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const FILE_LIST_WIDTH_KEY = "reown-filelist-width";
+const FILE_LIST_COLLAPSED_KEY = "reown-filelist-collapsed";
+const DEFAULT_FILE_LIST_WIDTH = 280;
+const MIN_FILE_LIST_WIDTH = 180;
+const MAX_FILE_LIST_WIDTH = 480;
+
+export function useFileListPanel() {
+  const [fileListWidth, setFileListWidth] = useState(() => {
+    try {
+      const stored = localStorage.getItem(FILE_LIST_WIDTH_KEY);
+      if (stored) {
+        const parsed = Number(stored);
+        if (parsed >= MIN_FILE_LIST_WIDTH && parsed <= MAX_FILE_LIST_WIDTH) {
+          return parsed;
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return DEFAULT_FILE_LIST_WIDTH;
+  });
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(FILE_LIST_COLLAPSED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const [resizing, setResizing] = useState(false);
+  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const toggleCollapse = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(FILE_LIST_COLLAPSED_KEY, String(next));
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      resizeRef.current = { startX: e.clientX, startWidth: fileListWidth };
+      setResizing(true);
+    },
+    [fileListWidth]
+  );
+
+  useEffect(() => {
+    if (!resizing) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!resizeRef.current) return;
+      const delta = e.clientX - resizeRef.current.startX;
+      const newWidth = Math.min(
+        MAX_FILE_LIST_WIDTH,
+        Math.max(MIN_FILE_LIST_WIDTH, resizeRef.current.startWidth + delta)
+      );
+      setFileListWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      setResizing(false);
+      resizeRef.current = null;
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [resizing]);
+
+  // Persist width when resizing ends
+  const prevResizingRef = useRef(false);
+  useEffect(() => {
+    if (prevResizingRef.current && !resizing) {
+      try {
+        localStorage.setItem(FILE_LIST_WIDTH_KEY, String(fileListWidth));
+      } catch {
+        // ignore
+      }
+    }
+    prevResizingRef.current = resizing;
+  }, [resizing, fileListWidth]);
+
+  return {
+    fileListWidth,
+    collapsed,
+    resizing,
+    toggleCollapse,
+    handleResizeStart,
+  };
+}


### PR DESCRIPTION
## Summary

Implements issue #619: refactor: useFileListPanel フックを FileListPanel と同じファイルに移動する

frontend/src/components/ReviewTab.tsx:36 — `useFileListPanel` フックは FileListPanel コンポーネントと密結合しているため、`FileListPanel.tsx` に移動するか専用ファイルに切り出すことで、再利用時のインポートが自然になる

---
_レビューエージェントが #562 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #619

---
Generated by agent/loop.sh