### PR TITLE
refactor: refactor: build_approve_comment の factors フォーマットを Markdown リストに統一

### DIFF
--- a/lib/automation/auto_approve.rs
+++ b/lib/automation/auto_approve.rs
@@ -108,7 +108,7 @@ fn build_approve_comment(candidate: &AutoApproveCandidate) -> String {
         let items: Vec<String> = candidate
             .factors
             .iter()
-            .map(|f| format!("  - {} (+{}) — {}", f.name, f.score, f.description))
+            .map(|f| format!("- **{}** (+{}) — {}", f.name, f.score, f.description))
             .collect();
         format!("\nFactors:\n{}", items.join("\n"))
     };
@@ -499,9 +499,9 @@ mod tests {
         assert!(comment.contains("Risk: Low (score: 15/100)"));
         assert!(comment.contains("Categories: Test, Documentation"));
         assert!(comment.contains("Factors:"));
-        assert!(comment.contains("file_count (+10)"));
+        assert!(comment.contains("**file_count** (+10)"));
         assert!(comment.contains("5ファイルが変更されています"));
-        assert!(comment.contains("line_count (+5)"));
+        assert!(comment.contains("**line_count** (+5)"));
     }
 
     #[test]
@@ -538,7 +538,7 @@ mod tests {
         let comment = build_approve_comment(&candidate);
         assert!(comment.contains("Risk: Medium (score: 40/100)"));
         assert!(comment.contains("Categories: Logic"));
-        assert!(comment.contains("no_tests (+15)"));
+        assert!(comment.contains("**no_tests** (+15)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements issue #624: refactor: build_approve_comment の factors フォーマットを Markdown リストに統一

lib/automation/auto_approve.rs:107 — 現在のフォーマット `  - name (+score) — description` はプレーンテキスト。GitHub コメントとして表示されるため Markdown リスト記法（`- **name** (+score) — description`）にすると視認性が向上する

---
_レビューエージェントが #577 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #624

---
Generated by agent/loop.sh