### PR TITLE
refactor: refactor: enable_auto_merge_with_base_url にも #[allow(clippy::too_many_arguments)] を追加

### DIFF
--- a/lib/github/pull_request.rs
+++ b/lib/github/pull_request.rs
@@ -787,6 +787,7 @@ impl GitHubClient {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn enable_auto_merge_with_base_url(
         &self,
         graphql_url: &str,


### PR DESCRIPTION
## Summary

Implements issue #745: refactor: enable_auto_merge_with_base_url にも #[allow(clippy::too_many_arguments)] を追加

lib/github/pull_request.rs:790 — enable_auto_merge_with_base_url は7引数あり submit_review_with_base_url と同じ引数数だが、clippy の allow 属性が付いていない。CI の clippy チェックで警告が出る可能性がある

---
_レビューエージェントが #626 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #745

---
Generated by agent/loop.sh