### PR TITLE
refactor: refactor: range slider の clamping を number input と統一する

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.tsx
+++ b/frontend/src/components/AutomationSettingsTab.tsx
@@ -481,7 +481,7 @@ export function AutomationSettingsTab() {
                     if (!isNaN(val)) {
                       setRiskConfig((prev) => ({
                         ...prev,
-                        missing_test_penalty: val,
+                        missing_test_penalty: Math.max(0, Math.min(val, 50)),
                       }));
                     }
                   }}


### PR DESCRIPTION
## Summary

Implements issue #630: refactor: range slider の clamping を number input と統一する

frontend/src/components/AutomationSettingsTab.tsx:477-484 — range slider の onChange ではクランプ処理（Math.max/Math.min）がないが、number input (L495-499) ではクランプしている。range input は HTML の min/max 属性で制限されるため実害はないが、防御的に統一したほうが良い。

---
_レビューエージェントが #589 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #630

---
Generated by agent/loop.sh