### PR TITLE
refactor: refactor: テストの invoke モック方法を統一する

### DIFF
--- a/frontend/src/components/SetupWizardStep2.test.tsx
+++ b/frontend/src/components/SetupWizardStep2.test.tsx
@@ -43,7 +43,7 @@ vi.mock("react-i18next", () => ({
 
 const mockInvokeFn = vi.fn();
 
-vi.mock("@tauri-apps/api/core", () => ({
+vi.mock("../invoke", () => ({
   invoke: (...args: unknown[]) => mockInvokeFn(...args),
 }));
 

--- a/frontend/src/components/SetupWizardStep3.test.tsx
+++ b/frontend/src/components/SetupWizardStep3.test.tsx
@@ -36,7 +36,7 @@ vi.mock("react-i18next", () => ({
 
 const mockInvokeFn = vi.fn();
 
-vi.mock("@tauri-apps/api/core", () => ({
+vi.mock("../invoke", () => ({
   invoke: (...args: unknown[]) => mockInvokeFn(...args),
 }));
 


### PR DESCRIPTION
## Summary

Implements issue #634: refactor: テストの invoke モック方法を統一する

SetupWizardStep2.test.tsx, SetupWizardStep3.test.tsx — `@tauri-apps/api/core` を直接モックしているが、コンポーネントは `../invoke` ラッパーを経由して呼び出している。invoke ラッパーの型安全性をテストから活用するため、`../invoke` をモックする方が適切。現状は `invoke` ラッパーが `tauriInvoke` に委譲するだけなので動作はするが、ラッパーにロジックが追加された場合にテストが実態と乖離するリスクがある。

---
_レビューエージェントが #601 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #634

---
Generated by agent/loop.sh