### PR TITLE
fix: refactor: react-i18next モックの重複を共通化する

### DIFF
--- a/frontend/src/components/AutoMergeBadge.test.tsx
+++ b/frontend/src/components/AutoMergeBadge.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { AutoMergeBadge } from "./AutoMergeBadge";
 import type { AutoMergeStatus } from "../types";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 describe("AutoMergeBadge", () => {
   describe("表示/非表示", () => {

--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 describe("ConfirmDialog", () => {
   const defaultProps = {

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -3,9 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { Layout } from "./Layout";
 import { fixtures } from "../storybook/fixtures";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const navItems = [
   { id: "review", labelKey: "nav.review", shortcut: "R" },

--- a/frontend/src/components/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { SetupWizard } from "./SetupWizard";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 // Mock step components to isolate navigation logic
 vi.mock("./SetupWizardStep1", () => ({

--- a/frontend/src/components/SetupWizardStep1.test.tsx
+++ b/frontend/src/components/SetupWizardStep1.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { SetupWizardStep1 } from "./SetupWizardStep1";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 describe("SetupWizardStep1", () => {
   const defaultProps = {

--- a/frontend/src/components/SetupWizardStep2.test.tsx
+++ b/frontend/src/components/SetupWizardStep2.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SetupWizardStep2 } from "./SetupWizardStep2";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const mockInvokeFn = vi.fn();
 

--- a/frontend/src/components/SetupWizardStep3.test.tsx
+++ b/frontend/src/components/SetupWizardStep3.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SetupWizardStep3 } from "./SetupWizardStep3";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const mockInvokeFn = vi.fn();
 

--- a/frontend/src/components/SetupWizardStep4.test.tsx
+++ b/frontend/src/components/SetupWizardStep4.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { SetupWizardStep4 } from "./SetupWizardStep4";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 describe("SetupWizardStep4", () => {
   it("renders the complete title and description", () => {

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -3,9 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
 import { fixtures } from "../storybook/fixtures";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const defaultProps = {
   repositories: fixtures.repositories,

--- a/frontend/src/components/TabBar.test.tsx
+++ b/frontend/src/components/TabBar.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { TabBar } from "./TabBar";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const items = [
   { id: "review", labelKey: "tabs.review", shortcut: "R" },

--- a/frontend/src/components/TodoTab.test.tsx
+++ b/frontend/src/components/TodoTab.test.tsx
@@ -4,9 +4,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TodoTab } from "./TodoTab";
 import { RepositoryProvider } from "../RepositoryContext";
 import { fixtures } from "../storybook/fixtures";
-import { i18nMock } from "../test/i18n-mock";
-
-vi.mock("react-i18next", () => i18nMock);
+vi.mock("react-i18next", async () => {
+  const { i18nMock } = await import("../test/i18n-mock");
+  return i18nMock;
+});
 
 const mockInvokeFn = vi.fn();
 

--- a/frontend/src/test/i18n-mock.ts
+++ b/frontend/src/test/i18n-mock.ts
@@ -34,7 +34,10 @@ function interpolate(
  * react-i18next の vi.mock 用ファクトリ。
  *
  * 使い方:
- *   vi.mock("react-i18next", () => i18nMock);
+ *   vi.mock("react-i18next", async () => {
+ *     const { i18nMock } = await import("../test/i18n-mock");
+ *     return i18nMock;
+ *   });
  */
 export const i18nMock = {
   useTranslation: () => ({


### PR DESCRIPTION
## Summary

Implements issue #635: refactor: react-i18next モックの重複を共通化する

3つのテストファイル全てに react-i18next のモック（翻訳辞書を含む）が重複して定義されている。テスト用の共通ヘルパーやフィクスチャに切り出すと保守性が向上する。

---
_レビューエージェントが #601 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #635

---
Generated by agent/loop.sh