### PR TITLE
test: test: SetupWizardStep3 の llm_api_key_stored フラグのテストを追加する

### DIFF
--- a/frontend/src/components/SetupWizardStep3.test.tsx
+++ b/frontend/src/components/SetupWizardStep3.test.tsx
@@ -171,6 +171,14 @@ describe("SetupWizardStep3", () => {
         apiKey: "sk-test-key",
       });
     });
+    // APIキーありの場合、llm_api_key_stored: true で保存される
+    expect(mockInvokeFn).toHaveBeenCalledWith("save_llm_config", {
+      llmConfig: {
+        llm_endpoint: "https://api.anthropic.com",
+        llm_model: "claude-sonnet-4-5-20250929",
+        llm_api_key_stored: true,
+      },
+    });
   });
 
   it("shows save error when save fails", async () => {


### PR DESCRIPTION
## Summary

Implements issue #636: test: SetupWizardStep3 の llm_api_key_stored フラグのテストを追加する

SetupWizardStep3.test.tsx:176-185 — APIキーあり時に `llm_api_key_stored: false` で save_llm_config を呼ぶことをアサートしているが、実装 (SetupWizardStep3.tsx:64) では `!!apiKey` を使うため APIキーあり時は `true` になるはず。テストの `llm_api_key_stored: false` アサーションは APIキー未入力のケースのものであり正しいが、APIキーを入力した場合に `llm_api_key_stored: true` になることをテストすると網羅性が上がる。

---
_レビューエージェントが #601 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #636

---
Generated by agent/loop.sh