### PR TITLE
fix: fix: evaluated フラグがキャンセル時にリセットされない

### DIFF
--- a/frontend/src/components/AutomationPanel.tsx
+++ b/frontend/src/components/AutomationPanel.tsx
@@ -130,7 +130,10 @@ export function AutomationPanel({ owner, repo }: AutomationPanelProps) {
           open={true}
           message={t("pr.autoApproveConfirm")}
           onConfirm={handleExecute}
-          onCancel={() => setPhase("idle")}
+          onCancel={() => {
+            setPhase("idle");
+            setEvaluated(false);
+          }}
           confirmLabel={t("pr.autoApproveRun")}
           confirmVariant="primary"
         >


### PR DESCRIPTION
## Summary

Implements issue #762: fix: evaluated フラグがキャンセル時にリセットされない

frontend/src/components/AutomationPanel.tsx:133 — confirm フェーズで onCancel が `setPhase('idle')` のみ行うが、`setEvaluated(false)` をリセットしていない。キャンセル後に「候補なし」メッセージが表示される（candidates は空にクリアされた状態で evaluated=true のまま）。ただし handleEvaluate で candidates は空にクリアされないため実際の不整合は軽微。

---
_レビューエージェントが #443 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #762

---
Generated by agent/loop.sh