### PR TITLE
test: test: Button の loading prop に対するユニットテストを追加する

### DIFF
--- a/frontend/src/components/Button.test.tsx
+++ b/frontend/src/components/Button.test.tsx
@@ -43,6 +43,36 @@ describe("Button", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
+  it("shows spinner svg when loading is true", () => {
+    const { container } = render(<Button loading>Loading</Button>);
+    const svg = container.querySelector("svg.animate-spin");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("does not show spinner svg when loading is false", () => {
+    const { container } = render(<Button>Normal</Button>);
+    const svg = container.querySelector("svg.animate-spin");
+    expect(svg).not.toBeInTheDocument();
+  });
+
+  it("still renders children alongside spinner when loading", () => {
+    render(<Button loading>Save</Button>);
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+
+  it("does not call onClick when loading", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Button loading onClick={handleClick}>
+        Loading
+      </Button>
+    );
+
+    await user.click(screen.getByRole("button"));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
   describe("variants", () => {
     it.each(["primary", "secondary", "destructive", "ghost"] as const)(
       "renders %s variant",


### PR DESCRIPTION
## Summary

Implements issue #643: test: Button の loading prop に対するユニットテストを追加する

frontend/src/components/Button.tsx:49-74 — loading 状態でスピナーが表示されること、disabled になることのテストが不足している

---
_レビューエージェントが #455 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #643

---
Generated by agent/loop.sh