### PR TITLE
test: test: ホバー時にショートカットバッジが非表示→表示になることをユニットテストで検証

### DIFF
--- a/frontend/src/components/TabBar.test.tsx
+++ b/frontend/src/components/TabBar.test.tsx
@@ -167,4 +167,21 @@ describe("TabBar", () => {
     await user.keyboard("{ArrowRight}");
     expect(onSelect).toHaveBeenCalledWith("review");
   });
+
+  it("shortcut badges are hidden by default and become visible on group hover via CSS classes", () => {
+    const { container } = render(
+      <TabBar
+        items={items}
+        activeId="review"
+        onSelect={vi.fn()}
+        showShortcuts
+      />
+    );
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
+    kbds.forEach((kbd) => {
+      expect(kbd).toHaveClass("hidden");
+      expect(kbd).toHaveClass("group-hover:inline-flex");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements issue #646: test: ホバー時にショートカットバッジが非表示→表示になることをユニットテストで検証

frontend/src/components/TabBar.test.tsx — ショートカットバッジがデフォルトで非表示(hidden)であること、ホバー時に表示されることのユニットテストが追加されていない。CSSクラスベースの表示/非表示はjsdomでは完全にテストできないが、クラス名の検証は可能。VRTではカバーされているが、ユニットテストでも最低限のクラス検証があると安心。

---
_レビューエージェントが #462 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #646

---
Generated by agent/loop.sh