### PR TITLE
fix: fix: Sidebar.tsxでshowShortcutsプロップが未使用

### DIFF
--- a/frontend/e2e/vrt/sidebar.spec.ts
+++ b/frontend/e2e/vrt/sidebar.spec.ts
@@ -11,9 +11,7 @@ test.describe("Sidebar", () => {
   });
 
   test("empty state", async ({ page }) => {
-    await page.goto(
-      "/iframe.html?id=components-sidebar--empty&viewMode=story"
-    );
+    await page.goto("/iframe.html?id=components-sidebar--empty&viewMode=story");
     await expect(page.locator("#storybook-root")).toHaveScreenshot("empty.png");
   });
 
@@ -71,7 +69,7 @@ test.describe("Sidebar", () => {
       "my-very-long-repository-name-that-exceeds-sidebar-width"
     );
     await repoButton.hover();
-    await page.waitForSelector('[data-radix-popper-content-wrapper]');
+    await page.waitForSelector("[data-radix-popper-content-wrapper]");
     await expect(page).toHaveScreenshot("tooltip-visible.png");
   });
 
@@ -138,6 +136,15 @@ test.describe("Sidebar", () => {
     );
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
       "collapsed-settings-open.png"
+    );
+  });
+
+  test("with shortcuts visible", async ({ page }) => {
+    await page.goto(
+      "/iframe.html?id=components-sidebar--with-shortcuts&viewMode=story"
+    );
+    await expect(page.locator("#storybook-root")).toHaveScreenshot(
+      "with-shortcuts.png"
     );
   });
 

--- a/frontend/src/components/Sidebar.stories.tsx
+++ b/frontend/src/components/Sidebar.stories.tsx
@@ -39,6 +39,12 @@ export const SettingsOpen: Story = {
   },
 };
 
+export const WithShortcuts: Story = {
+  args: {
+    showShortcuts: true,
+  },
+};
+
 export const LongRepoName: Story = {
   args: {
     repositories: [

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -132,9 +132,18 @@ describe("Sidebar", () => {
     expect(settingsButton).toHaveAttribute("aria-keyshortcuts", "S");
   });
 
-  it("hides kbd shortcut from screen readers", () => {
+  it("hides kbd shortcut badge when showShortcuts is false", () => {
     const { container } = render(<Sidebar {...defaultProps} />);
     const kbd = container.querySelector("kbd");
+    expect(kbd).not.toBeInTheDocument();
+  });
+
+  it("shows kbd shortcut badge when showShortcuts is true", () => {
+    const { container } = render(
+      <Sidebar {...defaultProps} showShortcuts={true} />
+    );
+    const kbd = container.querySelector("kbd");
+    expect(kbd).toBeInTheDocument();
     expect(kbd).toHaveAttribute("aria-hidden", "true");
   });
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -74,6 +74,7 @@ export function Sidebar({
   onToggleCollapse,
   width,
   loading = false,
+  showShortcuts = false,
 }: Props) {
   const { t } = useTranslation();
   const [removingRepo, setRemovingRepo] = useState<RepositoryEntry | null>(
@@ -436,12 +437,14 @@ export function Sidebar({
               >
                 <SettingsGearIcon />
                 {t("tabs.settings")}
-                <kbd
-                  aria-hidden="true"
-                  className="ml-auto rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted"
-                >
-                  S
-                </kbd>
+                {showShortcuts && (
+                  <kbd
+                    aria-hidden="true"
+                    className="ml-auto rounded border border-border-hover bg-bg-hint px-1.5 text-[0.7rem] text-text-muted"
+                  >
+                    S
+                  </kbd>
+                )}
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary

Implements issue #768: fix: Sidebar.tsxでshowShortcutsプロップが未使用

frontend/src/components/Sidebar.tsx:58 — showShortcutsプロップがPropsインターフェースに追加され、destructureされているが、コンポーネント内で実際に使用されていない。Sidebarにもショートカットバッジがあるなら同様に条件付きレンダリングが必要

---
_レビューエージェントが #436 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #768

---
Generated by agent/loop.sh