### PR TITLE
refactor: refactor: VRTスナップショットファイル名の不一致を修正

### DIFF
--- a/frontend/e2e/vrt/tabbar.spec.ts
+++ b/frontend/e2e/vrt/tabbar.spec.ts
@@ -44,7 +44,7 @@ test.describe("TabBar", () => {
     );
     await page.locator('[role="tab"]').first().hover();
     await expect(page.locator("#storybook-root")).toHaveScreenshot(
-      "shortcut-on-hover.png"
+      "shortcut-badge-visible-on-hover.png"
     );
   });
 


### PR DESCRIPTION
## Summary

Implements issue #647: refactor: VRTスナップショットファイル名の不一致を修正

frontend/e2e/vrt/tabbar.spec.ts:47 — スクリーンショット名が `shortcut-on-hover.png` だが、テスト名から自動生成されるディレクトリ名は `TabBar-shortcut-badge-visible-on-hover`。ファイル名をテスト名と合わせて `shortcut-badge-visible-on-hover.png` にするとスナップショットの管理が明確になる。

---
_レビューエージェントが #462 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #647

---
Generated by agent/loop.sh