### PR TITLE
docs: docs: commit_with_formatter_retry の戻り値ドキュメントと実装の不一致

### DIFF
--- a/agent/lib/30_git.sh
+++ b/agent/lib/30_git.sh
@@ -123,7 +123,7 @@ git_add_safe() {
 # Commit uncommitted changes with formatter retry on pre-commit hook failure.
 # If `git commit` fails (e.g. pre-commit hook), re-runs formatters and retries.
 # Usage: commit_with_formatter_retry "commit message"
-# Returns 0 if committed (or nothing to commit), non-zero on failure.
+# Returns 0 always (best-effort commit; callers do not check return value).
 commit_with_formatter_retry() {
   local commit_msg="$1"
   cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary

Implements issue #662: docs: commit_with_formatter_retry の戻り値ドキュメントと実装の不一致

agent/lib/30_git.sh:126 — docstring に「non-zero on failure」とあるが、最終行の `git commit ... || true` (L150) により常に 0 を返す。docstring を修正するか、戻り値を正しく返すようにすべき。呼び出し元 (07_ci.sh) は戻り値を使用していないため実害はない

---
_レビューエージェントが #555 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #662

---
Generated by agent/loop.sh