### PR TITLE
refactor: refactor: tab variant の active/inactive でラウンド指定が重複

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -27,14 +27,14 @@ const variantClasses: Record<Variant, string> = {
     "bg-transparent text-text-primary border border-transparent hover:bg-bg-hover hover:border-border-hover",
   filter:
     "bg-bg-hover text-text-secondary font-medium border-none hover:text-text-primary",
-  tab: "rounded-none rounded-t border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary",
+  tab: "border-b-2 border-b-transparent bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary",
 };
 
 const filterActiveClasses =
   "bg-accent text-white font-bold shadow-sm ring-1 ring-accent";
 
 const tabActiveClasses =
-  "rounded-none rounded-t border-b-2 border-b-accent bg-accent/10 font-bold text-accent";
+  "border-b-2 border-b-accent bg-accent/10 font-bold text-accent";
 
 const sizeClasses: Record<Size, string> = {
   sm: "px-2 py-1 text-sm",
@@ -63,7 +63,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           ? tabActiveClasses
           : variantClasses[variant];
 
-    const roundedClass = variant === "tab" ? "" : "rounded";
+    const roundedClass =
+      variant === "tab" ? "rounded-none rounded-t" : "rounded";
 
     return (
       <button


### PR DESCRIPTION
## Summary

Implements issue #666: refactor: tab variant の active/inactive でラウンド指定が重複

frontend/src/components/Button.tsx:30,37 — `tab` variant の variantClasses と tabActiveClasses の両方に `rounded-none rounded-t` が記述されている。roundedClass の条件分岐（L66）と合わせて、rounded の制御が3箇所に分散している。tabActiveClasses から rounded 指定を削除するか、variantClasses 側で統一すると保守性が上がる

---
_レビューエージェントが #659 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #666

---
Generated by agent/loop.sh