### PR TITLE
refactor: refactor: ThemeSettingsTab に aria-selected パターンの検討

### DIFF
--- a/frontend/src/components/ThemeSettingsTab.tsx
+++ b/frontend/src/components/ThemeSettingsTab.tsx
@@ -1,3 +1,4 @@
+import { useCallback, type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Card } from "./Card";
 import { useTheme, type Theme } from "../ThemeContext";
@@ -7,6 +8,31 @@ const THEME_OPTIONS: Theme[] = ["light", "dark", "system"];
 export function ThemeSettingsTab() {
   const { t } = useTranslation();
   const { theme, setTheme } = useTheme();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const currentIndex = THEME_OPTIONS.indexOf(theme);
+      let nextIndex: number | null = null;
+
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        nextIndex = (currentIndex + 1) % THEME_OPTIONS.length;
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        nextIndex =
+          (currentIndex - 1 + THEME_OPTIONS.length) % THEME_OPTIONS.length;
+      }
+
+      if (nextIndex !== null) {
+        e.preventDefault();
+        const nextTheme = THEME_OPTIONS[nextIndex];
+        setTheme(nextTheme);
+        const group = e.currentTarget;
+        const buttons =
+          group.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+        buttons[nextIndex]?.focus();
+      }
+    },
+    [theme, setTheme]
+  );
 
   return (
     <div className="space-y-6">
@@ -21,12 +47,14 @@ export function ThemeSettingsTab() {
           className="flex items-center gap-1 rounded border border-border p-0.5"
           role="radiogroup"
           aria-label={t("theme.label")}
+          onKeyDown={handleKeyDown}
         >
           {THEME_OPTIONS.map((option) => (
             <button
               key={option}
               role="radio"
               aria-checked={theme === option}
+              tabIndex={theme === option ? 0 : -1}
               onClick={() => setTheme(option)}
               className={`flex-1 cursor-pointer rounded border-none px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 theme === option


### PR DESCRIPTION
## Summary

Implements issue #674: refactor: ThemeSettingsTab に aria-selected パターンの検討

frontend/src/components/ThemeSettingsTab.tsx:28 — role="radio" + aria-checked は正しいが、キーボードナビゲーション（矢印キー操作）が未実装。WAI-ARIA Radio Group パターンに準拠するなら矢印キーでのフォーカス移動を追加すべき

---
_レビューエージェントが #461 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #674

---
Generated by agent/loop.sh