### PR TITLE
refactor: refactor: FileDiffLegend を独立ファイルに抽出

### DIFF
--- a/frontend/src/components/AnalysisDetailPanel.tsx
+++ b/frontend/src/components/AnalysisDetailPanel.tsx
@@ -10,6 +10,7 @@ import type {
 import { Card, Panel } from "./Card";
 import { Badge } from "./Badge";
 import { RiskBadge } from "./RiskBadge";
+import { FileDiffLegend } from "./FileDiffLegend";
 
 interface AnalysisDetailPanelProps {
   result: AnalysisResult;
@@ -156,24 +157,6 @@ function RiskFactorList({ factors }: { factors: RiskFactor[] }) {
           </span>
         </div>
       ))}
-    </div>
-  );
-}
-
-export function FileDiffLegend() {
-  const { t } = useTranslation();
-
-  return (
-    <div className="flex items-center gap-3 text-[0.75rem] text-text-secondary">
-      <span>{t("pr.fileDiffLegend")}</span>
-      <span className="flex items-center gap-1">
-        <span className="inline-block h-2 w-2 rounded-full bg-accent" />
-        <span>+ {t("pr.fileDiffLegendAdditions")}</span>
-      </span>
-      <span className="flex items-center gap-1">
-        <span className="inline-block h-2 w-2 rounded-full bg-danger" />
-        <span>- {t("pr.fileDiffLegendDeletions")}</span>
-      </span>
     </div>
   );
 }

--- a/frontend/src/components/FileDiffLegend.stories.tsx
+++ b/frontend/src/components/FileDiffLegend.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import i18n from "../i18n";
-import { FileDiffLegend } from "./AnalysisDetailPanel";
+import { FileDiffLegend } from "./FileDiffLegend";
 
 const meta = {
   title: "Components/FileDiffLegend",

--- a/frontend/src/components/FileDiffLegend.tsx
+++ b/frontend/src/components/FileDiffLegend.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from "react-i18next";
+
+export function FileDiffLegend() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-3 text-[0.75rem] text-text-secondary">
+      <span>{t("pr.fileDiffLegend")}</span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+        <span>+ {t("pr.fileDiffLegendAdditions")}</span>
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block h-2 w-2 rounded-full bg-danger" />
+        <span>- {t("pr.fileDiffLegendDeletions")}</span>
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements issue #677: refactor: FileDiffLegend を独立ファイルに抽出

frontend/src/components/AnalysisDetailPanel.tsx:160 — FileDiffLegend は AnalysisDetailPanel.tsx 内で定義されているが、export されて Stories からも参照されるようになったため、独立したファイル（FileDiffLegend.tsx）に抽出した方が見通しが良い

---
_レビューエージェントが #571 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #677

---
Generated by agent/loop.sh