### PR TITLE
refactor: refactor: auto_approve.rs の #[serde(default)] 追加の関連性を明確にする

### DIFF
--- a/lib/automation/auto_approve.rs
+++ b/lib/automation/auto_approve.rs
@@ -14,12 +14,18 @@ pub struct AutoApproveCandidate {
     /// リスクレベル
     pub risk_level: RiskLevel,
     /// リスクスコア（0〜100）
+    ///
+    /// Tauri IPC経由でフロントエンドからデシリアライズされる際、省略可能にするため `default` を指定
     #[serde(default)]
     pub risk_score: u32,
     /// 変更カテゴリ一覧
+    ///
+    /// Tauri IPC経由でフロントエンドからデシリアライズされる際、省略可能にするため `default` を指定
     #[serde(default)]
     pub categories: Vec<ChangeCategory>,
     /// 主要リスク要因の内訳
+    ///
+    /// Tauri IPC経由でフロントエンドからデシリアライズされる際、省略可能にするため `default` を指定
     #[serde(default)]
     pub factors: Vec<RiskFactor>,
     /// approve対象になった理由


### PR DESCRIPTION
## Summary

Implements issue #685: refactor: auto_approve.rs の #[serde(default)] 追加の関連性を明確にする

lib/automation/auto_approve.rs:15,18 — `risk_score` と `categories` への `#[serde(default)]` 追加はissue #578（reqwest::Client共有化）のスコープ外に見える。別コミットまたは別issueで管理すべき

---
_レビューエージェントが #578 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #685

---
Generated by agent/loop.sh