### PR TITLE
test: test: SliderInteraction で nativeInputValueSetter の非null アサーションを安全にする

### DIFF
--- a/frontend/src/components/AutomationSettingsTab.stories.tsx
+++ b/frontend/src/components/AutomationSettingsTab.stories.tsx
@@ -208,10 +208,16 @@ export const SliderInteraction: Story = {
     // 最初のスライダー（Logic）の値を変更
     const logicSlider = sliders[0];
     // nativeInputValueSetter を使って React の state を更新
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    const descriptor = Object.getOwnPropertyDescriptor(
       HTMLInputElement.prototype,
       "value"
-    )!.set!;
+    );
+    if (!descriptor?.set) {
+      throw new Error(
+        "HTMLInputElement.prototype.value の setter が見つかりません"
+      );
+    }
+    const nativeInputValueSetter = descriptor.set;
     nativeInputValueSetter.call(logicSlider, "2.5");
     logicSlider.dispatchEvent(new Event("input", { bubbles: true }));
     logicSlider.dispatchEvent(new Event("change", { bubbles: true }));


### PR DESCRIPTION
## Summary

Implements issue #709: test: SliderInteraction で nativeInputValueSetter の非null アサーションを安全にする

frontend/src/components/AutomationSettingsTab.stories.tsx:210 — `Object.getOwnPropertyDescriptor(...)!.set!` で非nullアサーションを2回使用している。プロトタイプの仕様上問題ないが、defensive なガード追加を検討

---
_レビューエージェントが #591 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #709

---
Generated by agent/loop.sh