### PR TITLE
test: test: unwrap() を serde_json::to_value で使用している

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1954,7 +1954,7 @@ mod tests {
         assert_eq!(config, reown::config::RiskConfig::default());
 
         // IPC経由でJSON化されることを確認
-        let json = serde_json::to_value(&config).unwrap();
+        let json = serde_json::to_value(&config).expect("RiskConfig should serialize");
         assert!(json["category_weights"].is_object());
         assert!(json["sensitive_patterns"].is_array());
         assert!(json["file_count_thresholds"].is_array());


### PR DESCRIPTION
## Summary

Implements issue #713: test: unwrap() を serde_json::to_value で使用している

app/src/main.rs:1957 — `serde_json::to_value(&config).unwrap()` はテストコードなので問題ないが、万が一 RiskConfig のシリアライズが壊れた場合にパニックメッセージが分かりにくい。`expect("RiskConfig should serialize")` にすると失敗時のデバッグが楽になる

---
_レビューエージェントが #596 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #713

---
Generated by agent/loop.sh