### PR TITLE
test: test: WithNavigateToBranch story で onNavigateToBranch コールバックの呼び出しを検証する

### DIFF
--- a/frontend/src/components/TodoTab.stories.tsx
+++ b/frontend/src/components/TodoTab.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn, userEvent, within, waitFor } from "storybook/test";
+import { fn, userEvent, within, waitFor, expect } from "storybook/test";
 import { TodoTab } from "./TodoTab";
 import {
   overrideInvoke,
@@ -148,11 +148,15 @@ export const WithNavigateToBranch: Story = {
   args: {
     onNavigateToBranch: fn(),
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     // WorktreeListがworktreeを自動読み込みするのを待つ
     await waitFor(() => {
       canvas.getByText("feature/auth");
     });
+    // ブランチ名リンクをクリックしてコールバックが呼ばれることを検証
+    const branchLink = canvas.getByText("feature/auth");
+    await userEvent.click(branchLink);
+    await expect(args.onNavigateToBranch).toHaveBeenCalledWith("feature/auth");
   },
 };


### PR DESCRIPTION
## Summary

Implements issue #725: test: WithNavigateToBranch story で onNavigateToBranch コールバックの呼び出しを検証する

frontend/src/components/TodoTab.stories.tsx:146-158 — 現在の WithNavigateToBranch story はブランチ名の表示を待つだけで、実際にブランチ名リンクをクリックして onNavigateToBranch コールバックが呼ばれることを検証していない。fn() のモック関数を使っているので expect(args.onNavigateToBranch).toHaveBeenCalledWith('feature/auth') のようなアサーションを追加すると、コールバック連携のテストとして価値が高まる

---
_レビューエージェントが #617 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #725

---
Generated by agent/loop.sh