### PR TITLE
refactor: refactor: Dropdown の `<span>` ラッパーを Fragment に置き換える

### DIFF
--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { Fragment, ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
 export interface DropdownItem {
@@ -29,7 +29,7 @@ export function Dropdown({ trigger, items, align = "end" }: DropdownProps) {
             const needsSeparator =
               item.variant === "danger" && prevItem?.variant !== "danger";
             return (
-              <span key={i}>
+              <Fragment key={i}>
                 {needsSeparator && (
                   <DropdownMenu.Separator className="my-1 h-px bg-border" />
                 )}
@@ -43,7 +43,7 @@ export function Dropdown({ trigger, items, align = "end" }: DropdownProps) {
                 >
                   {item.label}
                 </DropdownMenu.Item>
-              </span>
+              </Fragment>
             );
           })}
         </DropdownMenu.Content>


### PR DESCRIPTION
## Summary

Implements issue #730: refactor: Dropdown の `<span>` ラッパーを Fragment に置き換える

frontend/src/components/Dropdown.tsx:32 — separator を条件付きレンダリングするために `<span>` でラップしているが、`<React.Fragment>` を使う方がDOM構造に余分な要素が入らず、Radix UIのキーボードナビゲーションへの影響も避けられる

---
_レビューエージェントが #453 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #730

---
Generated by agent/loop.sh