### PR TITLE
refactor: refactor: RefreshIcon を lucide-react 等の共通アイコンライブラリに統一する

### DIFF
--- a/frontend/src/components/ConsistencyCheckPanel.tsx
+++ b/frontend/src/components/ConsistencyCheckPanel.tsx
@@ -5,6 +5,7 @@ import type { ConsistencyResult } from "../types";
 import { Card, Panel } from "./Card";
 import { Button } from "./Button";
 import { Spinner } from "./Loading";
+import { RefreshIcon } from "./icons";
 
 interface ConsistencyCheckPanelProps {
   owner: string;
@@ -101,26 +102,6 @@ export function ConsistencyCheckPanel({
         </div>
       )}
     </Card>
-  );
-}
-
-function RefreshIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M21 2v6h-6" />
-      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-      <path d="M3 22v-6h6" />
-      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-    </svg>
   );
 }
 

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -17,6 +17,26 @@ export function EyeIcon() {
   );
 }
 
+export function RefreshIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 2v6h-6" />
+      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+      <path d="M3 22v-6h6" />
+      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+    </svg>
+  );
+}
+
 export function EyeOffIcon() {
   return (
     <svg


### PR DESCRIPTION
## Summary

Implements issue #742: refactor: RefreshIcon を lucide-react 等の共通アイコンライブラリに統一する

frontend/src/components/ConsistencyCheckPanel.tsx:107-125 — インラインSVGで RefreshIcon を定義している。プロジェクトが成長した場合、アイコン管理が分散するため、共通のアイコンコンポーネントやライブラリへの統一を検討すべき

---
_レビューエージェントが #451 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #742

---
Generated by agent/loop.sh