### PR TITLE
refactor: refactor: TodoTab.test.tsx の invoke モックも統一する

### DIFF
--- a/frontend/src/components/TodoTab.test.tsx
+++ b/frontend/src/components/TodoTab.test.tsx
@@ -11,7 +11,7 @@ vi.mock("react-i18next", async () => {
 
 const mockInvokeFn = vi.fn();
 
-vi.mock("@tauri-apps/api/core", () => ({
+vi.mock("../invoke", () => ({
   invoke: (...args: unknown[]) => mockInvokeFn(...args),
 }));
 


### PR DESCRIPTION
## Summary

Implements issue #755: refactor: TodoTab.test.tsx の invoke モックも統一する

frontend/src/components/TodoTab.test.tsx:39 — `@tauri-apps/api/core` を直接モックしている。今回の変更で SetupWizard 系テストは `../invoke` ラッパーのモックに統一されたが、TodoTab.test.tsx は旧パターンのまま残っている。同じ方針で統一すべき。

---
_レビューエージェントが #634 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #755

---
Generated by agent/loop.sh