### PR TITLE
chore: chore: 未使用の mockReactI18next エクスポートを削除

### DIFF
--- a/frontend/src/test/i18n-mock.ts
+++ b/frontend/src/test/i18n-mock.ts
@@ -1,4 +1,3 @@
-import { vi } from "vitest";
 import ja from "../i18n/locales/ja.json";
 
 type NestedRecord = { [key: string]: string | NestedRecord };
@@ -51,8 +50,3 @@ const translationResult = { t };
 export const i18nMock = {
   useTranslation: () => translationResult,
 };
-
-/** vi.mock のファクトリ関数として直接渡す用 */
-export function mockReactI18next() {
-  vi.mock("react-i18next", () => i18nMock);
-}


### PR DESCRIPTION
## Summary

Implements issue #757: chore: 未使用の mockReactI18next エクスポートを削除

frontend/src/test/i18n-mock.ts:51 — `mockReactI18next()` 関数がエクスポートされているが、どのテストファイルからも使用されていない。全テストは `i18nMock` オブジェクトを直接インポートしている。デッドコードとして削除すべき。

---
_レビューエージェントが #635 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #757

---
Generated by agent/loop.sh