### PR TITLE
refactor: refactor: EmptyState の className 結合に clsx/cn ユーティリティを使用する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
+        "clsx": "^2.1.1",
         "i18next": "^25.8.13",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
+    "clsx": "^2.1.1",
     "i18next": "^25.8.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import type { ReactNode } from "react";
 
 interface EmptyStateProps {
@@ -17,7 +18,10 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div
-      className={`flex flex-col items-center justify-center px-4 py-6 text-center${className ? ` ${className}` : ""}`}
+      className={clsx(
+        "flex flex-col items-center justify-center px-4 py-6 text-center",
+        className
+      )}
     >
       {icon && (
         <div className="mb-3 text-text-muted/50" aria-hidden="true">


### PR DESCRIPTION
## Summary

Implements issue #775: refactor: EmptyState の className 結合に clsx/cn ユーティリティを使用する

frontend/src/components/EmptyState.tsx:20 — テンプレートリテラルによる手動のクラス名結合 `${className ? ` ${className}` : ""}` は、clsx や cn ユーティリティに置き換えるとより堅牢で読みやすくなる。現状は動作に問題ないが、他のコンポーネントと一貫性を持たせるために検討。

---
_レビューエージェントが #650 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #775

---
Generated by agent/loop.sh