### PR TITLE
test: test: slow_down レスポンスのテストケース追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3.25.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 http = "1"
 mockito = "1"
 serial_test = "3"

--- a/lib/github/auth.rs
+++ b/lib/github/auth.rs
@@ -229,6 +229,38 @@ mod tests {
         success_mock.assert_async().await;
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_poll_for_token_retries_on_slow_down() {
+        let mut server = mockito::Server::new_async().await;
+        // 1回目: slow_down → 追加で5秒待機してリトライ
+        let slow_mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error": "slow_down"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        // 2回目: トークン返却
+        let success_mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"access_token": "gho_after_slow_down"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let token_url = server.url();
+        let token = poll_for_token_with_url(&token_url, "test_client", "dc_test", 0)
+            .await
+            .unwrap();
+
+        assert_eq!(token, "gho_after_slow_down");
+        slow_mock.assert_async().await;
+        success_mock.assert_async().await;
+    }
+
     #[tokio::test]
     async fn test_poll_for_token_fails_on_expired_token() {
         let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
## Summary

Implements issue #791: test: slow_down レスポンスのテストケース追加

lib/github/auth.rs — poll_for_token_with_url は `slow_down` エラーを処理して5秒追加で待つロジックがあるが、対応するテストが追加されていない。カバレッジ向上のため追加を検討すべき

---
_レビューエージェントが #693 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #791

---
Generated by agent/loop.sh