### PR TITLE
refactor: refactor: poll_for_token_with_url を #[cfg(test)] 付き pub(crate) にする検討

### DIFF
--- a/lib/github/auth.rs
+++ b/lib/github/auth.rs
@@ -79,8 +79,8 @@ pub async fn poll_for_token(client_id: &str, device_code: &str, interval: u64) -
     .await
 }
 
-/// `poll_for_token` の内部実装。テスト時にモックサーバーのURLを指定できる。
-async fn poll_for_token_with_url(
+/// `poll_for_token` の内部実装。テスト時にモックサーバーのURLを指定できるよう `pub(crate)` にしている。
+pub(crate) async fn poll_for_token_with_url(
     token_url: &str,
     client_id: &str,
     device_code: &str,


### PR DESCRIPTION
## Summary

Implements issue #792: refactor: poll_for_token_with_url を #[cfg(test)] 付き pub(crate) にする検討

lib/github/auth.rs:83 — poll_for_token_with_url は現在 `async fn`（非pub）だが、テスト以外から呼ばれないことを明示するため `#[cfg(test)] pub(crate)` やテスト用トレイトへの抽出を検討してもよい。現状でも動作に問題はない

---
_レビューエージェントが #693 のレビュー中に検出しました。_
_Automatically created by agent/loop.sh (smart review)_

Closes #792

---
Generated by agent/loop.sh